### PR TITLE
GPAPB with empty data will crash NMEA communication

### DIFF
--- a/pypilot/nmea.py
+++ b/pypilot/nmea.py
@@ -156,16 +156,17 @@ def parse_nmea_apb(line):
         '''
     if line[3:6] != 'APB':
         return False
-    
-    data = line[7:len(line)-3].split(',')
-    mode = 'compass' if data[13] == 'M' else 'gps'
-    command = float(data[12])
-    xte = float(data[2])
-    xte = min(xte, 0.15) # maximum 0.15 miles
-    if data[3] == 'L':
+    try
+       data = line[7:len(line)-3].split(',')
+       mode = 'compass' if data[13] == 'M' else 'gps'
+       command = float(data[12])
+       xte = float(data[2])
+       xte = min(xte, 0.15) # maximum 0.15 miles
+       if data[3] == 'L':
         xte = -xte
-    return 'apb', {'mode': mode, 'track':  track, 'xte': xte, '**': line[1:3] == 'GP'}
-
+       return 'apb', {'mode': mode, 'track':  track, 'xte': xte, '**': line[1:3] == 'GP'}
+    except: 
+       return false
 
 nmea_parsers = {'gps': parse_nmea_gps, 'wind': parse_nmea_wind, 'rudder': parse_nmea_rudder, 'apb': parse_nmea_apb}
 

--- a/pypilot/sensors.py
+++ b/pypilot/sensors.py
@@ -119,10 +119,8 @@ class APB(Sensor):
         mode = self.server.values['ap.mode']
         if mode.value != data['mode']:
             # for GPAPB, ignore message on wrong mode
-            if data['**'] == 'GP':
-                return
-            
-            mode.set(data['mode'])
+            if data['**'] != 'GP':
+                mode.set(data['mode'])
 
         command = data['track'] + self.gain.value*data['xte']
 


### PR DESCRIPTION
As (Garmin) plotters produce GPAPB with empty data when no active waypoint it will crash nmea communication by doing a float on an empty string without try except. With RMC and MWV there is a try except only on APB it is missing.