### PR TITLE
fix error when running pypilot_boatimu

### DIFF
--- a/pypilot/pilots/__init__.py
+++ b/pypilot/pilots/__init__.py
@@ -1,16 +1,2 @@
 # import all scripts in this directory
-
-from __future__ import print_function
-default = []
-
-import os
-for module in os.listdir(os.path.dirname(__file__)):
-    if module == '__init__.py' or module[-3:] != '.py' or module.startswith('.'):
-        continue
-    try:
-        __import__('pilots.'+module[:-3], locals(), globals())
-    except Exception as e:
-        print('ERROR loading', module, e)
-    del module
-
-default += [simple.SimplePilot, basic.BasicPilot, learning.LearningPilot, wind.WindPilot]
+import simple, basic, learning, wind

--- a/scripts/debian/etc/systemd/system/pypilot_boatimu.service
+++ b/scripts/debian/etc/systemd/system/pypilot_boatimu.service
@@ -5,7 +5,7 @@ Conflicts=pypilot.service
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/pypilot_boatimu
+ExecStart=pypilot_boatimu -q
 StandardOutput=syslog
 StandardError=syslog
 User=pi


### PR DESCRIPTION
this was the error:

```
ERROR loading simple.py No module named pilots.simple
ERROR loading learning.py No module named pilots.learning
ERROR loading wind.py No module named pilots.wind
ERROR loading basic.py No module named pilots.basic
Traceback (most recent call last):
  File "/usr/local/bin/pypilot_boatimu", line 11, in <module>
    load_entry_point('pypilot==0.9', 'console_scripts', 'pypilot_boatimu')()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 489, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2793, in load_entry_point
    return ep.load()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2411, in load
    return self.resolve()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2417, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/local/lib/python2.7/dist-packages/pypilot-0.9-py2.7-linux-armv7l.egg/pypilot/boatimu.py", line 20, in <module>
    import autopilot
  File "/usr/local/lib/python2.7/dist-packages/pypilot-0.9-py2.7-linux-armv7l.egg/pypilot/autopilot.py", line 182, in <module>
    import pilots
  File "/usr/local/lib/python2.7/dist-packages/pypilot-0.9-py2.7-linux-armv7l.egg/pypilot/pilots/__init__.py", line 16, in <module>
    default += [simple.SimplePilot, basic.BasicPilot, learning.LearningPilot, wind.WindPilot]
NameError: name 'simple' is not defined
```