### PR TITLE
Added missing backslash to fix wrong dead time when running at 4MHz

### DIFF
--- a/arduino/motor/motor.ino
+++ b/arduino/motor/motor.ino
@@ -131,7 +131,7 @@ PWR+             VIN
 #define dead_time \
     asm volatile ("nop"); \
     asm volatile ("nop"); \
-    asm volatile ("nop");
+    asm volatile ("nop"); \
     asm volatile ("nop");
 #elif DIV_CLOCK==2
 #define dead_time \


### PR DESCRIPTION
Preprocessor was giving warning.