### PR TITLE
fix boatimu error

### DIFF
--- a/pypilot/boatimu.py
+++ b/pypilot/boatimu.py
@@ -253,7 +253,7 @@ class BoatIMU(object):
     self.server = server
 
     self.rate = self.Register(EnumProperty, 'rate', 10, [10, 25], persistent=True)
-    self.period = 1.0/self.rate.value
+    self.period = 1.0/float(self.rate.value)
 
     self.loopfreq = self.Register(LoopFreqValue, 'loopfreq', 0)
     self.alignmentQ = self.Register(QuaternionValue, 'alignmentQ', [1, 0, 0, 0], persistent=True)


### PR DESCRIPTION
This change fixes this error:

Traceback (most recent call last):
  File "/usr/local/bin/pypilot_boatimu", line 11, in <module>
    load_entry_point('pypilot==0.12', 'console_scripts', 'pypilot_boatimu')()
  File "/usr/local/lib/python3.7/dist-packages/pypilot-0.12-py3.7-linux-armv7l.egg/pypilot/boatimu.py", line 512, in main
    boatimu = BoatIMUServer()
  File "/usr/local/lib/python3.7/dist-packages/pypilot-0.12-py3.7-linux-armv7l.egg/pypilot/boatimu.py", line 490, in __init__
    self.boatimu = BoatIMU(self.server)
  File "/usr/local/lib/python3.7/dist-packages/pypilot-0.12-py3.7-linux-armv7l.egg/pypilot/boatimu.py", line 256, in __init__
    self.period = 1.0/self.rate.value
TypeError: unsupported operand type(s) for /: 'float' and 'str'