### PR TITLE
Fix reading port from config file for the pypilot web

### DIFF
--- a/web/README
+++ b/web/README
@@ -20,7 +20,7 @@ Optionaly, a port number can be specified in the first argument
     sudo python web.py 8080  
 ```
 
-Or provided from a json config file at ['port':8080] . 
+Or provided from a json config file at {"port":8080} .
 
 If no port is specified, the default value is 80.
 

--- a/web/web.py
+++ b/web/web.py
@@ -8,7 +8,7 @@
 # version 3 of the License, or (at your option) any later version.  
 
 from __future__ import print_function
-import time, sys
+import time, sys, json, os
 from flask import Flask, render_template, session, request
 from flask_socketio import SocketIO, Namespace, emit, join_room, leave_room, \
     close_room, rooms, disconnect
@@ -18,7 +18,7 @@ pypilot_web_port=80
 if len(sys.argv) > 1:
     pypilot_web_port=int(sys.argv[1])
 else:
-    filename = '~/.pypilot/web.conf'
+    filename = os.getenv('HOME')+'/.pypilot/web.conf'
     try:
         file = open(filename, 'r')
         config = json.loads(file.readline())


### PR DESCRIPTION
 On RPI, armbian and linux mint. I was unable to read port from the configuration file.  

The ~ sign was not working to resolve the path so used the getenv('HOME')

json lib was missing

and I had to modify the example in the doc, single quotes and square brackets where causing json.reads error.  


Im not used to code python so I hope did it the right way. 
