### PR TITLE
Add Quotes around variable value to make it a string.

### DIFF
--- a/hat/config.py
+++ b/hat/config.py
@@ -1,3 +1,3 @@
-address = 10.10.10.177
+address = '10.10.10.177'
 essid = 'openplotter'
 psk = '12345678'


### PR DESCRIPTION
Compiler complain about:
```File "/usr/lib/python3.8/dist-packages/pypilot/hat/config.py", line 1
    address = 10.10.10.177
                   ^
SyntaxError: invalid syntax
```
