### PR TITLE
Add dependencies to services

### DIFF
--- a/scripts/debian/etc/systemd/system/pypilot_hat.service
+++ b/scripts/debian/etc/systemd/system/pypilot_hat.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=pypilot hat
 DefaultDependencies=false
+Requires=pypilot.service
 
 [Service]
 Type=simple

--- a/scripts/debian/etc/systemd/system/pypilot_webapp.service
+++ b/scripts/debian/etc/systemd/system/pypilot_webapp.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=pypilot web
 DefaultDependencies=false
+Requires=pypilot.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
When performing upgrade, bringing pypilot.service down also brings other services down. Note: openplotter installs similar services.