### PR TITLE
Fix font character creation with newer Pillow versions

### DIFF
--- a/hat/font.py
+++ b/hat/font.py
@@ -132,7 +132,7 @@ def create_character(fontpath, size, c, bypp, crop, bpp):
         data = list(image.getdata())
         for i in range(len(data)):
             d = 255 / (1<<bpp)
-            v = int(round(data[i][0] / (255 / (1<<bpp))) * (255 / ((1<<bpp)-1)))
+            v = int(round(data[i][3] / (255 / (1<<bpp))) * (255 / ((1<<bpp)-1)))
             data[i] = (v,v,v,v)
         image.putdata(data)
 


### PR DESCRIPTION
Draw.text() behaviour changed at some time between the old Pillow
used by Sean's tinypilot and newer ones: in the older ones, pixels
being drawn had values like (x, x, x, x) (meaning red=green=blue=alpha),
while newer ones generates pixel with values like (255, 255, 255, x)
(meaning only alpha channel varies with the value).

This broke pypilot hat font generation, because only the 'red'
component was being used.

Change this to use the 'alpha' component instead, which makes both
old and new Pillow version to work.