### PR TITLE
Fix hat.ino verify/flash from inside pypilot_hat

### DIFF
--- a/hat/hat.py
+++ b/hat/hat.py
@@ -276,6 +276,10 @@ class Hat(object):
         host = self.config['host']
         print('host', host)
 
+        if 'arduino' in self.config['hat']:
+            import arduino
+            arduino.arduino(config).firmware()
+
         self.poller = select.poll()
         self.gpio = gpio.gpio()
         self.lcd = LCD(self)


### PR DESCRIPTION
ISP flashing behaves badly when the display is already doing SPI transfers, so do all the verify/flash firmware steps before launching the LCD process.