### PR TITLE
Fix motor controller stuck in MAX/MIN_RUDDER_FAULT

### DIFF
--- a/arduino/motor/motor.ino
+++ b/arduino/motor/motor.ino
@@ -1378,8 +1378,10 @@ void loop()
                 flags |= MAX_RUDDER_FAULT;
             } else
                 flags &= ~MAX_RUDDER_FAULT;
-            if(v < 1024+1024 || v > 65472 - 1024)
+            if(v < 1024+1024 || v > 65472 - 1024) {
                 rudder_sense = 0;
+                flags &= ~(MIN_RUDDER_FAULT | MAX_RUDDER_FAULT);
+            }
         } else {
             if(v > 1024+1536 && v < 65472 - 1536)
                 rudder_sense = 1;


### PR DESCRIPTION
If for some reason the rudder sense readings becomes out of range (could be because the rudder sense has simply been disconnected), ADC reading will become out of range, and will trigger a MAX or MIN_RUDDER_FAULT, then rudder sense will be disabled in the driver until the reading comes again into range. Which will never happen.

I have also reproduced this on my PCNautic tiller pilot, which has rudder sense feedback based on a potentiometer which reads from 0 to 10k, while the motor controller expects something more close to 1k to 9k. Fully extended or shortened tiller pilot will then behave the same as if it was disconnected.