### PR TITLE
Fix center button line break

### DIFF
--- a/web/static/dark_theme.css
+++ b/web/static/dark_theme.css
@@ -218,13 +218,7 @@ body[theme="dark"] #configuration_container .w3-row {
 /* Steer button styling */
 body[theme="dark"] #steer_buttons_container {
 	margin-top: 10px;
-	margin-left: 0.1%;
-	margin-right: 0.1%;
 	padding-top: 10px;
-	padding-left: 5px;
-	padding-right: 5px;
-	border: 1px solid #253036;
-	border-radius: 3px;
 	overflow: hidden;
 }
 

--- a/web/static/index.css
+++ b/web/static/index.css
@@ -1,3 +1,6 @@
+#steer_buttons_container{
+	text-align: center;
+}
 .toggle-button {
     background-color: white;
     margin: 0 10% 0 0;

--- a/web/static/pypilot_control.js
+++ b/web/static/pypilot_control.js
@@ -798,6 +798,8 @@ $(document).ready(function() {
 
     function window_resize() {
         var w = $(window).width();
+        var wbc = $('#steer_buttons_container').width();
+
         $(".font-resizable").each(function(i, obj) {
             if (w < 600)
                 $(this).css('font-size', w/18+"px")
@@ -813,8 +815,12 @@ $(document).ready(function() {
         $(".font-resizable3").each(function(i, obj) {
             $(this).css('font-size', w/50+"px")
         });
-        $(".button-resizable").each(function(i, obj) {
+        $(".button-resizable").not("#steer_buttons_container .button-resizable").each(function(i, obj) {
             $(this).css('width', w/5+"px")
+            $(this).css('height', w/6+"px")
+        });
+        $("#steer_buttons_container .button-resizable").each(function(i, obj) {
+            $(this).css('width', (wbc/5)-(w*.01)+"px")
             $(this).css('height', w/6+"px")
         });
         $(".button-resizable1").each(function(i, obj) {

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -56,15 +56,15 @@
 >
       </div>
       <div id="steer_buttons_container" class="w3-row" >
-          <button id="port10" class="button font-resizable1 button-resizable">
+          <button id="port10" class="button font-resizable1 button-resizable" style="float:left">
             <span id="port10">--</span>
           </button>
-          <button id="port1" class="button font-resizable1 button-resizable"> <!-- force no space between buttons-->
+          <button id="port1" class="button font-resizable1 button-resizable" style="float:left"> <!-- force no space between buttons-->
             <span id="port1">--</span>
           </button>
           <span id="center_span">
           <button id="center_button" class="button font-resizable1 button-resizable">
-            <span id="center"></span>
+            <span id="center">|</span>
           </button>
           </span>
           <button id="star10" class="button font-resizable1 button-resizable" style="float:right">


### PR DESCRIPTION
When the center button is displayed, the buttons are no longer displayed in a row. This is because some margins/paddings are not taken into account when calculating the button width.

Before:
![grafik](https://github.com/pypilot/pypilot/assets/1258468/7d5c5145-0a66-4577-926b-fbc28f2ed990)

After:
![grafik](https://github.com/pypilot/pypilot/assets/1258468/3d3cc35a-ec54-4705-b262-4e8c5980184e)
