### PR TITLE
Probe nmea with 460800 speed (multiplex shipmodule)

### DIFF
--- a/pypilot/nmea.py
+++ b/pypilot/nmea.py
@@ -513,7 +513,7 @@ class Nmea(object):
                 serialprobe.relinquish('nmea%d' % self.probeindex)
             self.probeindex = index
 
-            self.probedevicepath = serialprobe.probe('nmea%d' % self.probeindex, [38400, 4800], 8)
+            self.probedevicepath = serialprobe.probe('nmea%d' % self.probeindex, [460800, 38400, 4800], 8)
             if self.probedevicepath:
                 print('nmea probe', self.probedevicepath)
                 try:


### PR DESCRIPTION
Hi,

I'm using a Shipmodule Miniplex connected via USB to my PyPilot setup.

It uses a usb to serial module at a 460800 baud rate. I would like to add this probe speed to auto detect the ShipModule.

Let me know if you have any request.

FYI : I tested this change and its working

```
...
server setup has 6 pipes
servo probe ('/dev/ttyAMA0', 38400) 429.087070981
nmea probe ('/dev/serial/by-id/usb-CustomWare_ShipModul_MiniPlex-3Wi_33020270-if00-port0', 460800)
server add socket ('127.0.0.1', 40010)
server add socket ('127.0.0.1', 40012)
ICM-20948 init complete
...
```