### PR TITLE
Add SignalK as external IMU source for BoatIMU

### DIFF
--- a/pypilot/boatimu.py
+++ b/pypilot/boatimu.py
@@ -403,6 +403,11 @@ class BoatIMU(object):
         
         self.auto_cal = AutomaticCalibrationProcess(client.server)
 
+        # source for imu data: 'local' (RTIMU hardware) or 'signalk'
+        self.source = self.register(StringValue, 'source', 'local', persistent=True)
+        # pipe for receiving external IMU data from signalk
+        self.signalk_pipe = None
+
         self.lasttimestamp = 0
 
         self.headingrate = self.heel = 0
@@ -457,11 +462,88 @@ class BoatIMU(object):
                 lastdata = data
         return self.imu.read()
 
+    def read_signalk(self):
+        """Read IMU data from SignalK pipe when no local IMU is available."""
+        if not self.signalk_pipe:
+            return False
+        lastdata = False
+        while True:
+            data = self.signalk_pipe.recv()
+            if not data:
+                break
+            lastdata = data
+        if not lastdata:
+            return False
+
+        # SignalK provides heading_lowpass, pitch, roll, headingrate_lowpass (in degrees)
+        # Build a minimal data dict compatible with the processing below
+        heading = lastdata.get('heading_lowpass', 0)
+        pitch = lastdata.get('pitch', 0)
+        roll = lastdata.get('roll', 0)
+        headingrate = lastdata.get('headingrate_lowpass', 0)
+
+        data = {}
+        data['timestamp'] = lastdata.get('timestamp', time.monotonic())
+        data['heading'] = heading
+        data['pitch'] = pitch
+        data['roll'] = roll
+        data['headingrate'] = headingrate
+        data['headingraterate'] = 0
+        data['rollrate'] = 0
+        data['pitchrate'] = 0
+        data['accel'] = [0, 0, 1]  # placeholder
+        data['gyro'] = [0, 0, 0]  # placeholder
+        data['compass'] = [0, 0, 0]  # placeholder
+        data['fusionQPose'] = [1, 0, 0, 0]  # identity quaternion
+        data['accel.residuals'] = data['accel']
+        return data
+
     def read(self):
         if not self.imu.multiprocessing:
             self.imu.poll()
 
         data = self.IMUread()
+
+        # If no local IMU data, try reading from SignalK
+        if not data and self.source.value == 'signalk':
+            data = self.read_signalk()
+            if data:
+                # SignalK data already has heading/pitch/roll in degrees
+                # Skip quaternion/gyro processing, go straight to filtering
+                self.last_imuread = time.monotonic()
+                self.frequency.strobe()
+
+                dt = data['timestamp'] - self.lasttimestamp
+                self.lasttimestamp = data['timestamp']
+                if dt > .01 and dt < 1:
+                    data['headingraterate'] = (data['headingrate'] - self.headingrate) / dt
+                else:
+                    data['headingraterate'] = 0
+
+                self.headingrate = data['headingrate']
+                data['heel'] = self.heel = data['roll']*.03 + self.heel*.97
+
+                # lowpass heading and rate
+                llp = self.heading_lowpass_constant.value
+                if self.reset_alignment:
+                    llp = 1
+                    self.reset_alignment = False
+                data['heading_lowpass'] = heading_filter(llp, data['heading'], self.SensorValues['heading_lowpass'].value)
+
+                llp = self.headingrate_lowpass_constant.value
+                data['headingrate_lowpass'] = llp*data['headingrate'] + (1-llp)*self.SensorValues['headingrate_lowpass'].value
+
+                llp = self.headingraterate_lowpass_constant.value
+                data['headingraterate_lowpass'] = llp*data['headingraterate'] + (1-llp)*self.SensorValues['headingraterate_lowpass'].value
+
+                # set sensors
+                for name in self.SensorValues:
+                    if name in data:
+                        self.SensorValues[name].set(data[name])
+
+                self.uptime.update()
+                return data
+
         if not data:
             if time.monotonic() - self.last_imuread > 1 and self.frequency.value:
                 print('IMURead failed!')

--- a/pypilot/sensors.py
+++ b/pypilot/sensors.py
@@ -377,6 +377,14 @@ class Sensors(object):
         self.signalk = signalk(self)
         self.gpsd = gpsd(self)
 
+        # wire signalk IMU data directly to BoatIMU (bypasses Sensors.write)
+        # always create the pipe - source value may not be loaded from config yet at init time
+        if boatimu:
+            from nonblockingpipe import NonBlockingPipe
+            imu_pipe_in, imu_pipe_out = NonBlockingPipe('signalk imu pipe', self.signalk.multiprocessing)
+            self.signalk.imu_pipe = imu_pipe_in
+            boatimu.signalk_pipe = imu_pipe_out
+
         # actual sensors supported
         self.gps = gps(client)
         self.wind = Wind(client, boatimu)

--- a/pypilot/signalk.py
+++ b/pypilot/signalk.py
@@ -131,6 +131,7 @@ class signalk(object):
         self.last_access_request_time = 0
 
         self.sensors_pipe, self.sensors_pipe_out = NonBlockingPipe('signalk pipe', self.multiprocessing)
+        self.imu_pipe = None  # set by Sensors.__init__ to send IMU data to BoatIMU
         self.zero_conf = ZeroConfProcess(self)
         
         if self.multiprocessing:
@@ -168,6 +169,11 @@ class signalk(object):
         self.period = self.client.register(RangeProperty('signalk.period', .5, .1, 2, persistent=True))
         self.last_period = False
         self.uid = self.client.register(Property('signalk.uid', 'pypilot', persistent=True))
+
+        # manual host:port fallback when zeroconf discovery fails
+        from values import StringValue
+        self.host = self.client.register(Property('signalk.host', '', persistent=True))
+        self.port = self.client.register(Property('signalk.port', 3000, persistent=True))
 
         self.signalk_host_port = False
         self.signalk_ws_url = False
@@ -324,7 +330,10 @@ class signalk(object):
             msg = self.sensors_pipe_out.recv()
             while msg:
                 sensor, data = msg
-                self.sensors.write(sensor, data, 'signalk')
+                if sensor == 'imu' and self.imu_pipe:
+                    self.imu_pipe.send(data)
+                elif sensor != 'imu':
+                    self.sensors.write(sensor, data, 'signalk')
                 msg = self.sensors_pipe_out.recv()
             return
 
@@ -345,7 +354,13 @@ class signalk(object):
         
         self.client.poll(timeout)
         if not self.signalk_host_port:
-            return # waiting for signalk to detect
+            # fallback: use manually configured host:port if zeroconf fails
+            if self.host.value:
+                host_port = self.host.value + ':' + str(int(self.port.value))
+                self.signalk_host_port = host_port
+                print('signalk ' + _('using configured host'), host_port)
+            else:
+                return # waiting for signalk to detect
 
         t1 = time.monotonic()
         if not self.signalk_ws_url:
@@ -465,6 +480,10 @@ class signalk(object):
         for sensor in signalk_table:
             if sensor != 'imu' and (not sensor in self.last_sources or\
                                     source_priority[self.last_sources[sensor]]>=signalk_priority):
+                #debug('signalk skip send from priority', sensor)
+                continue
+            # don't send imu data back to signalk when we're receiving it from signalk
+            if sensor == 'imu' and self.subscribed.get('imu'):
                 #debug('signalk skip send from priority', sensor)
                 continue
             sensork = sensor


### PR DESCRIPTION
- Add imu.source property to BoatIMU (local/signalk)
- Route IMU data from SignalK websocket through sensors_pipe to BoatIMU
- Register signalk.host/port properties as fallback when zeroconf fails
- Prevent echoing IMU data back to SignalK when receiving from it
- Always create IMU pipe regardless of source value at init time