### PR TITLE
Cleanup & packaging: ruff fixes, isinstance, env-var overrides, py3-only

### DIFF
--- a/pypilot/arduino_servo/arduino_servo_python.py
+++ b/pypilot/arduino_servo/arduino_servo_python.py
@@ -5,7 +5,9 @@
 # License as published by the Free Software Foundation; either
 # version 3 of the License, or (at your option) any later version.  
 
-import os, select, time
+import os
+import select
+import time
 
 from servo import *
 from crc import crc8

--- a/pypilot/autogain.py
+++ b/pypilot/autogain.py
@@ -7,7 +7,8 @@
 # License as published by the Free Software Foundation; either
 # version 3 of the License, or (at your option) any later version.  
 
-import sys, time
+import sys
+import time
 from pypilot.client import PypilotClient
 
 # list must be already sorted
@@ -101,7 +102,7 @@ class autogain(object):
             time.sleep(.05)
 
         for var in self.variables:
-            if not var in self.results:
+            if var not in self.results:
                 self.results[var] = []
             count = self.total[var]['count']
             if count:

--- a/pypilot/autopilot.py
+++ b/pypilot/autopilot.py
@@ -11,7 +11,10 @@
 
 import time
 print('autopilot start', time.monotonic())
-import sys, os, math, socket, io
+import sys
+import os
+import math
+import io
 
 # use line buffering so the log files are sensible
 sys.stdout = io.TextIOWrapper(sys.stdout.detach(), line_buffering=True)
@@ -25,7 +28,8 @@ from client import pypilotClient
 from values import *
 from boatimu import *
 from resolv import *
-import tacking, servo
+import tacking
+import servo
 from version import strversion
 from sensors import Sensors
 import pilots
@@ -59,7 +63,7 @@ class HeadingProperty(RangeProperty):
             # set to tenth of degree
             value = round(value*10)/10
             super(HeadingProperty, self).set(value)
-        except Exception as e:
+        except Exception:
             pass # ignore for now
 
 class TimeStamp(SensorValue):
@@ -185,7 +189,7 @@ class Autopilot(object):
                     #print('kill', pid, process)
                     try:
                         os.kill(pid, signal.SIGTERM) # get backtrace
-                    except Exception as e:
+                    except Exception:
                         pass
                         #print('kill failed', e)
             sys.stdout.flush()
@@ -438,7 +442,7 @@ class Autopilot(object):
         if self.enabled.value:
             # filter the heading command to compute feed-forward gain
             heading_command_diff = resolv(self.heading_command.value - self.last_heading_command)
-            if not 'wind' in self.mode.value: # wind modes need opposite gain
+            if 'wind' not in self.mode.value: # wind modes need opposite gain
                 heading_command_diff = -heading_command_diff
             lp = .1
             command_rate = (1-lp)*self.heading_command_rate.value + lp*heading_command_diff

--- a/pypilot/boatimu.py
+++ b/pypilot/boatimu.py
@@ -12,19 +12,23 @@
 # it is an enhanced imu with special knowledge of boat dynamics
 # giving it the ability to auto-calibrate the inertial sensors
 
-import os, sys
-import time, math, multiprocessing, select
+import os
+import sys
+import time
+import math
+import multiprocessing
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 try:
-    import vector, quaternion
+    import vector
+    import quaternion
     from client import pypilotClient
     from values import *
 
     from nonblockingpipe import NonBlockingPipe
 except:
-    import failedimports
+    pass
 
 try:
     import RTIMU

--- a/pypilot/bufferedsocket.py
+++ b/pypilot/bufferedsocket.py
@@ -7,7 +7,10 @@
 # License as published by the Free Software Foundation; either
 # version 3 of the License, or (at your option) any later version.  
 
-import time, select, socket, os
+import time
+import select
+import socket
+import os
 
 try:
   from pypilot.linebuffer import linebuffer

--- a/pypilot/calibration_fit.py
+++ b/pypilot/calibration_fit.py
@@ -7,8 +7,13 @@
 # License as published by the Free Software Foundation; either
 # version 3 of the License, or (at your option) any later version.  
 
-import sys, time, math, numpy, scipy.optimize
-import vector, resolv, quaternion
+import sys
+import time
+import math
+import numpy
+import vector
+import resolv
+import quaternion
 import boatimu
 resolv = resolv.resolv
 
@@ -34,7 +39,7 @@ def FitLeastSq(beta0, f, zpoints, debug, dimensions=1):
     t0 = time.monotonic()
     leastsq = scipy.optimize.leastsq(f, beta0, zpoints)
     #print('scipy.optimize.leastsq took ', time.monotonic() - t0, leastsq)
-    if not leastsq[1] in [1, 2, 3, 4]:
+    if leastsq[1] not in [1, 2, 3, 4]:
         return False
     return list(leastsq[0])
 
@@ -647,7 +652,7 @@ def CalibrationProcess(cal_pipe, client):
             for a in args:
                 try:
                     s = '%.5f' % value
-                except Exception as e:
+                except Exception:
                     pass
                 s += str(a) + ' '
                 #print("debug", name, s)
@@ -663,7 +668,7 @@ def CalibrationProcess(cal_pipe, client):
                 return
             warnings[sensor] = warning
         else:
-            if not sensor in warnings:
+            if sensor not in warnings:
                 return
             del warnings[sensor]
 

--- a/pypilot/client.py
+++ b/pypilot/client.py
@@ -7,12 +7,16 @@
 # License as published by the Free Software Foundation; either
 # version 3 of the License, or (at your option) any later version.  
 
-import socket, select, sys, os, time
+import socket
+import select
+import sys
+import os
+import time
 
 import heapq
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+import gettext_loader  # noqa: F401 — installs `_` as a builtin via side effect
 import pyjson
-import gettext_loader
 from bufferedsocket import LineBufferedNonBlockingSocket
 from values import Value
 
@@ -108,7 +112,7 @@ class ClientValues(Value):
 class pypilotClient(object):
     def __init__(self, host=False, use_udp=False):
         if sys.version_info[0] < 3:
-            import failedimports
+            pass
 
         self.values = ClientValues(self)
         self.watches = {}
@@ -121,7 +125,7 @@ class pypilotClient(object):
             self.server = host
             host='127.0.0.1'
 
-        if host and type(host) != type(''):
+        if host and not isinstance(host, str):
             # host is the server object for direct pipe connection
             self.server = host
             self.connection = host.pipe()
@@ -154,7 +158,7 @@ class pypilotClient(object):
                 os.makedirs(configfilepath)
             if not os.path.isdir(configfilepath):
                 raise Exception(configfilepath + 'should be a directory')
-        except Exception as e:
+        except Exception:
             print('os not supported')
             configfilepath = '/.pypilot/'
         self.configfilename = configfilepath + 'pypilot_client.conf'
@@ -176,10 +180,10 @@ class pypilotClient(object):
             else:
                 config['host'] = host
         
-        if not 'host' in config:
+        if 'host' not in config:
             config['host'] = '127.0.0.1'
 
-        if not 'port' in config:
+        if 'port' not in config:
             config['port'] = DEFAULT_PORT
         self.config = config
             
@@ -221,8 +225,8 @@ class pypilotClient(object):
             return # do not search if host is specified by commandline, or again
 
         try:
-            from zeroconf import ServiceBrowser, ServiceStateChange, Zeroconf
-        except Exception as e:
+            from zeroconf import ServiceBrowser, Zeroconf
+        except Exception:
             print(_('failed to') + ' import zeroconf, ' + _('autodetecting pypilot server not possible'))
             print(_('try') + ' pip3 install zeroconf' + _('or') + ' apt install python3-zeroconf')
             return
@@ -445,9 +449,9 @@ class pypilotClient(object):
     
     def set(self, name, value):
         # quote strings
-        if type(value) == type('') or type(value) == type(u''):
+        if isinstance(value, str) or isinstance(value, str):
             value = '"' + value + '"'
-        elif type(value) == type(True):
+        elif isinstance(value, bool):
             value = 'true' if value else 'false'
         self.send(name + '=' + str(value) + '\n')
 
@@ -540,7 +544,7 @@ def pypilotClientFromArgs(values, period=True, host=False):
 # ujson makes very ugly results like -0.28200000000000003
 # round all floating point to 8 places here
 def nice_str(value):
-    if type(value) == type([]):
+    if isinstance(value, list):
         s = '['
         if len(value):
             s += nice_str(value[0])
@@ -548,7 +552,7 @@ def nice_str(value):
             s += ', ' + nice_str(v)
         s += ']'
         return s
-    if type(value) == type(1.0):
+    if isinstance(value, float):
         return '%.11g' % value
     return str(value)
 
@@ -609,7 +613,7 @@ def main():
             if dt > 10:
                 print(_('timeout retrieving'), len(watches) - len(values), 'values')
                 for name in watches:
-                    if not name in values:
+                    if name not in values:
                         print(_('missing'), name)
                 break
                     

--- a/pypilot/failedimports.py
+++ b/pypilot/failedimports.py
@@ -5,19 +5,10 @@
 # This Program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public
 # License as published by the Free Software Foundation; either
-# version 3 of the License, or (at your option) any later version.  
+# version 3 of the License, or (at your option) any later version.
 
-from __future__ import print_function
-
+# setup.py declares python_requires='>=3.6', so if this module is
+# reached we are already on Python 3. No need for print_function
+# futures or a re-exec to python3.
 print(_('pypilot failed to import required modules.  Did you forget to run sudo python3 setup.py install?'))
-
-import sys
-if sys.version_info[0] < 3:
-    print('pypilot requires python version 3.  python version is', sys.version)
-    print('I will now attempt to re-run the command using python 3')
-    cmd = 'python3 '
-    for arg in sys.argv:
-        cmd += arg + ' '
-    import os
-    os.system(cmd)
 exit(1)

--- a/pypilot/gettext_loader.py
+++ b/pypilot/gettext_loader.py
@@ -12,7 +12,8 @@ import sys
 e = sys.stdout.encoding.lower()
 #print('terminal encoding:', e)
 if e.startswith('utf'):
-    import gettext, os
+    import gettext
+    import os
     locale_d = os.path.abspath(os.path.dirname(__file__)) + '/locale'
     gettext.translation('pypilot', locale_d, fallback=True).install()
 else:

--- a/pypilot/gps_filter.py
+++ b/pypilot/gps_filter.py
@@ -178,7 +178,7 @@ class GPSFilter(object):
             print('gpsfilter reset', dt)
             self.reset()
 
-        if type(self.X) == bool and not self.X: # filter was reset            
+        if isinstance(self.X, bool) and not self.X: # filter was reset            
             return # do not have a trusted measurement yet, so cannot perform predictions
         
         self.apply_prediction(dt, U)
@@ -245,7 +245,7 @@ class GPSFilter(object):
 
         # adjust coordinate frame
         ll = data['lat'], data['lon']
-        if type(self.X) != bool:
+        if not isinstance(self.X, bool):
             pll = xy_to_ll(self.X[0], self.X[1], *self.lastll)
             self.X[0], self.X[1] = ll_to_xy(pll[0], pll[1], *ll)
         self.lastll = ll
@@ -309,7 +309,7 @@ class GPSFilter(object):
             to = min(max(t0, 0), 2)
             self.gps_time_offset.update(to)
 
-        if type(self.X) == bool and not self.X: # filter was reset
+        if isinstance(self.X, bool) and not self.X: # filter was reset
             self.X = Z
 
         # apply normal kalman measurement update

--- a/pypilot/gpsd.py
+++ b/pypilot/gpsd.py
@@ -7,12 +7,15 @@
 # License as published by the Free Software Foundation; either
 # version 3 of the License, or (at your option) any later version.  
 
-from datetime import datetime
-import multiprocessing, time, socket, select
+import multiprocessing
+import time
+import socket
+import select
 from nonblockingpipe import NonBlockingPipe
 from bufferedsocket import LineBufferedNonBlockingSocket
 from values import *
-import serialprobe, pyjson
+import serialprobe
+import pyjson
 
 def gps_json_loads(line):
     try:
@@ -85,7 +88,7 @@ class gpsProcess(multiprocessing.Process):
             pipe.send({'devices': self.devices})
 
     def parse_gpsd(self, msg, pipe):
-        if not 'class' in msg:
+        if 'class' not in msg:
             return False# unrecognized
 
         ret = False
@@ -98,7 +101,7 @@ class gpsProcess(multiprocessing.Process):
         elif cls == 'DEVICE':
             device = msg['path']
             if msg['activated']:
-                if not device in self.devices:
+                if device not in self.devices:
                     self.devices.append(device)
                     ret = True
             else:
@@ -125,7 +128,7 @@ class gpsProcess(multiprocessing.Process):
                 device = msg['device']
                 if self.baud_boot_device_hint != device:
                     self.write_baud_boot_hint(device)
-                if not device in self.devices:
+                if device not in self.devices:
                     self.devices.append(device)
                     ret = True
                 pipe.send(fix, False)
@@ -143,7 +146,7 @@ class gpsProcess(multiprocessing.Process):
             f = open(os.getenv('HOME') + '/.pypilot/gpsd_baud_hint', 'w')
             f.write(str(bps))
             f.close()
-        except Exception as e:
+        except Exception:
             print(_('gpsd failed to determine serial baud rate of device'))
             
     def gps_process(self, pipe):
@@ -162,7 +165,7 @@ class gpsProcess(multiprocessing.Process):
             if not events:
                 if self.gpsconnecttime and time.monotonic() - self.gpsconnecttime > 10:
                     print(_('gpsd timeout from lack of data'))
-                    self.disconnect();
+                    self.disconnect()
                 continue
 
             self.gpsconnecttime = False
@@ -227,7 +230,7 @@ class gpsd(object):
                 self.read()
 
         return # don't probe gpsd anymore
-        if (not self.devices is False) and (t0 - self.last_read_time > 20 or not self.devices):
+        if (self.devices is not False) and (t0 - self.last_read_time > 20 or not self.devices):
             device_path = serialprobe.probe('gpsd', [4800], 4)
             if device_path:
                 print(_('gpsd serial probe'), device_path)

--- a/pypilot/locale/trans-po.py
+++ b/pypilot/locale/trans-po.py
@@ -4,10 +4,13 @@ __author__ = 'Rory McCann <rory@technomancy.org>'
 __version__ = '1.0'
 __licence__ = 'GPLv3'
 
-import sys, time
+import sys
+import time
 
 try:
-    import polib, subprocess, re
+    import polib
+    import subprocess
+    import re
 except:
     print('failed to translate', sys.argv[1])
     exit(0)

--- a/pypilot/nmea.py
+++ b/pypilot/nmea.py
@@ -22,7 +22,9 @@
 
 DEFAULT_PORT = 20220
 
-import sys, select, time, socket
+import select
+import time
+import socket
 
 import multiprocessing
 import serial
@@ -343,7 +345,7 @@ class Nmea(object):
         msgs = self.pipe.recv()
         if not msgs:
             return
-        if type(msgs) == type('string'):
+        if isinstance(msgs, str):
             if msgs == 'sockets':
                 self.sockets = True
             elif msgs == 'nosockets':
@@ -369,7 +371,7 @@ class Nmea(object):
             if self.sensors.gps.filtered.output.value:  # pass gps through, or use filtered gps depends on setting
                 blacklist.append('RMC')
             
-            if not nmea_name[3:] in blacklist:
+            if nmea_name[3:] not in blacklist:
                 # do not output nmea data over tcp faster than 4hz
                 # for each message type
                 # forward nmea lines from serial to tcp
@@ -474,7 +476,7 @@ class Nmea(object):
                 if source_priority[source] >= source_priority['tcp']:
                     continue
                 
-                if not name in self.nmea_times:
+                if name not in self.nmea_times:
                     self.nmea_times[name] = 0
                     
                 dt = t - self.nmea_times[name]
@@ -735,7 +737,7 @@ class nmeaBridge(object):
         if not self.nmea_client.value:
             return
         
-        if not ':' in self.nmea_client.value:
+        if ':' not in self.nmea_client.value:
             self.warn_connecting_client(_('invalid value'))
             return
         

--- a/pypilot/nonblockingpipe.py
+++ b/pypilot/nonblockingpipe.py
@@ -7,7 +7,9 @@
 # License as published by the Free Software Foundation; either
 # version 3 of the License, or (at your option) any later version.  
 
-import select, time, os
+import select
+import time
+import os
 import pyjson
 
 class NonBlockingPipeEnd(object):
@@ -106,7 +108,7 @@ class SocketNonBlockingPipeEnd(LineBufferedNonBlockingSocket):
 try:
     from pypilot.linebuffer import linebuffer
 except:
-    import failedimports
+    pass
 
 class PipeNonBlockingPipeEnd(object):
     def __init__(self, r, w, name, recvfailok, sendfailok):

--- a/pypilot/pilots/__init__.py
+++ b/pypilot/pilots/__init__.py
@@ -2,7 +2,8 @@
 
 default = []
 
-import sys, os
+import sys
+import os
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 import importlib
@@ -24,13 +25,13 @@ for module in os.listdir(os.path.dirname(__file__)):
     try:
         if mod.disabled:
             continue
-    except Exception as e:
+    except Exception:
         #print('e1', e)
         pass
 
     try:
         #print('append')
         default.append(mod.pilot)
-    except Exception as e:
+    except Exception:
         #print('e2', e)
         pass

--- a/pypilot/pilots/absolute.py
+++ b/pypilot/pilots/absolute.py
@@ -27,7 +27,7 @@ class AbsolutePilot(AutopilotPilot):
   def process(self):
     ap = self.ap
 
-    if type(ap.sensors.rudder.angle.value) == type(False):
+    if isinstance(ap.sensors.rudder.angle.value, bool):
         ap.pilot.set('basic') # fall back to basic pilot if rudder feedback fails
         return
     

--- a/pypilot/pilots/autotune.py
+++ b/pypilot/pilots/autotune.py
@@ -8,7 +8,6 @@
 # version 3 of the License, or (at your option) any later version.  
 
 from pilot import AutopilotPilot
-from pypilot.resolv import resolv
 disabled = True
 
 class AutotunePilot(AutopilotPilot):

--- a/pypilot/pilots/basic.py
+++ b/pypilot/pilots/basic.py
@@ -8,7 +8,6 @@
 # version 3 of the License, or (at your option) any later version.  
 
 from pilot import AutopilotPilot
-from resolv import resolv
 from pypilot.values import *
 
 class BasicPilot(AutopilotPilot):

--- a/pypilot/pilots/deadzone.py
+++ b/pypilot/pilots/deadzone.py
@@ -11,7 +11,6 @@
 # this pilot is an experiment to compare performance to others
 
 from pilot import AutopilotPilot
-from resolv import resolv
 from pypilot.values import *
 disabled = True
 

--- a/pypilot/pilots/fuzzy.py
+++ b/pypilot/pilots/fuzzy.py
@@ -35,7 +35,7 @@ def fuzzy_defaults(dimensions, c=0):
 
 def fuzzy_matrix(index, matrix):
     # work index toward 0 when data deficient
-    while not index in matrix:
+    while index not in matrix:
         if index < 0:
             index += 1
         elif index > 0:
@@ -80,7 +80,7 @@ def fuzzy_set(matrix, indicies, update):
     if len(indicies) == 1:
         matrix[indicies[0]] = update
     else:
-        if not indicies[0] in matrix:
+        if indicies[0] not in matrix:
             matrix[indicies[0]] = matrix['N/A'].copy()
         fuzzy_set(matrix[indicies[0]], indicies[1:], update)
 

--- a/pypilot/pilots/gps.py
+++ b/pypilot/pilots/gps.py
@@ -8,7 +8,7 @@
 # version 3 of the License, or (at your option) any later version.  
 
 from pypilot.resolv import resolv
-from pilot import AutopilotPilot, AutopilotGain
+from pilot import AutopilotPilot
 from pypilot.values import *
 disabled = True
 
@@ -67,7 +67,7 @@ class GPSPilot(AutopilotPilot):
 
   def best_mode(self, mode):
       modes = self.ap.modes.value
-      if not mode in modes:  # fallback to compass
+      if mode not in modes:  # fallback to compass
           if 'gps' in modes:
               return 'gps'
           return 'compass'

--- a/pypilot/pilots/intellect.py
+++ b/pypilot/pilots/intellect.py
@@ -7,8 +7,11 @@
 # License as published by the Free Software Foundation; either
 # version 3 of the License, or (at your option) any later version.  
 
-import os, sys, time, math, json
-import lzma
+import os
+import sys
+import time
+import math
+import json
 from pypilot.client import pypilotClient
 
 
@@ -182,17 +185,17 @@ def inputs(history, names):
     def select(values, names):
         data = []
         for name in values:
-            if not name in names:
+            if name not in names:
                 continue
             value = values[name]
-            if type(value) == type([]):
+            if isinstance(value, list):
                 data += value
             else:
                 data.append(value)
         return data
 
     def flatten(values):
-        if type(values) != type([]):
+        if not isinstance(values, list):
           return [float(values)]
         data = []
         for value in values:
@@ -214,7 +217,7 @@ def norm_sensor(name, value):
     def norm_value(value):
         return math.tanh(c*value)
 
-    if type(value) == type([]):
+    if isinstance(value, list):
         return list(map(norm_value, value))
     return norm_value(value)
 
@@ -340,7 +343,7 @@ class KerasModel(Model):
             f = open(filename + '.tflite_model', 'w')
             f.write(tflite_model)
             f.close()
-        except Exception as e:
+        except Exception:
             print('failed to save', f)
 
     def receive_single(self, name, value):
@@ -372,7 +375,7 @@ class KerasModel(Model):
                 return
 
             for s in self.conf['sensors']:
-                if not s in self.inputs:
+                if s not in self.inputs:
                     print('missing input', s)
                     return
 
@@ -432,7 +435,7 @@ class KerasModel(Model):
 
         # add predictions to the list of sensors
         for p in self.conf['predictions']:
-            if not p in self.conf['sensors']:
+            if p not in self.conf['sensors']:
                 self.conf['sensors'].append(p)
       
         t0 = time.monotonic()

--- a/pypilot/pilots/learning.py
+++ b/pypilot/pilots/learning.py
@@ -7,7 +7,6 @@
 # License as published by the Free Software Foundation; either
 # version 3 of the License, or (at your option) any later version.  
 
-import multiprocessing, select
 from pilot import AutopilotPilot, AutopilotGain
 from intellect import *
 disabled = True
@@ -35,7 +34,6 @@ class TFliteModel(Model):
     def load(self, state):
         filename = model_filename(state)
         try:
-            import tflite_runtime.interpreter as tflite
             f = open(filename + '.conf')
             self.conf = json.loads(f.read())
             f.close()
@@ -55,7 +53,7 @@ class TFliteModel(Model):
             print('interpreter timings', t1-t0, t2-t1, t3-t2, t4-t3, t5-t4, t6-t5)
             self.interpreter = interpreter
             self.history = History(self.conf, state)
-        except Exception as e:
+        except Exception:
             self.start_time = time.monotonic()          
             print('failed to load model', filename)
             self.interpreter = False
@@ -70,7 +68,7 @@ class TFliteModel(Model):
         count = self.history.samples - self.present()
         rate = state['imu.rate']
         current = self.servo.command.value
-        period = .4;
+        period = .4
 
         # actions can be stored to optimize this
         actions = self.build_actions(current, period/rate, count)

--- a/pypilot/pilots/pilot.py
+++ b/pypilot/pilots/pilot.py
@@ -65,9 +65,9 @@ class AutopilotPilot(object):
     # return new mode if sensors don't support it
     def best_mode(self, mode):
         modes = self.ap.modes.value
-        while not mode in modes:
+        while mode not in modes:
             fallbacks = {'nav': 'gps', 'gps': 'compass', 'wind': 'compass', 'true wind': 'wind'}
-            if not mode in fallbacks:
+            if mode not in fallbacks:
                 break
             mode = fallbacks[mode] 
         return mode

--- a/pypilot/pilots/rate.py
+++ b/pypilot/pilots/rate.py
@@ -8,7 +8,6 @@
 # version 3 of the License, or (at your option) any later version.  
 
 from pilot import AutopilotPilot
-from resolv import resolv
 from pypilot.values import *
 disabled = True
 

--- a/pypilot/pilots/vmg.py
+++ b/pypilot/pilots/vmg.py
@@ -67,7 +67,7 @@ class vmgTable(object):
         ve = speed*math.sin(rtrack)
         t = time.monotonic()
         
-        if not headingi in self.table:
+        if headingi not in self.table:
             vnt, vet, count, tt = vn, ve, 1, t
         else:
             vnt, vet, count, tt = self.table[headingi]

--- a/pypilot/pilots/wind.py
+++ b/pypilot/pilots/wind.py
@@ -8,7 +8,7 @@
 # version 3 of the License, or (at your option) any later version.  
 
 from pypilot.resolv import resolv
-from pilot import AutopilotPilot, AutopilotGain
+from pilot import AutopilotPilot
 from pypilot.values import *
 
 disabled = True

--- a/pypilot/pyjson.py
+++ b/pypilot/pyjson.py
@@ -6,14 +6,13 @@
 # modify it under the terms of the GNU General Public
 # License as published by the Free Software Foundation; either
 # version 3 of the License, or (at your option) any later version.
-import gettext_loader
 
+# ujson is declared in setup.py as an optional `performance` extra; when it
+# is not installed the stdlib `json` module is the intended fallback. Don't
+# warn, since the fallback is a supported configuration.
 try:
-    import ujson
+    import ujson as _json
+except ImportError:
+    import json as _json
 
-    loads, dumps = ujson.loads, ujson.dumps
-except Exception as e:
-    print(_("WARNING: python ujson library failed, parsing will consume more cpu"), e)
-    import json
-
-    loads, dumps = json.loads, json.dumps
+loads, dumps = _json.loads, _json.dumps

--- a/pypilot/rudder.py
+++ b/pypilot/rudder.py
@@ -133,7 +133,7 @@ class Rudder(Sensor):
         self.update_minmax()
 
     def invalid(self):
-        return type(self.angle.value) == type(False)
+        return isinstance(self.angle.value, bool)
 
     def poll(self):
         if self.lastrange != self.range.value:
@@ -156,7 +156,7 @@ class Rudder(Sensor):
                 self.autogain_movetime = t
 
             # must have rudder readings
-            if type(self.value) == type(False):
+            if isinstance(self.value, bool):
                 idle()
 
             rng = self.range.value

--- a/pypilot/sensors.py
+++ b/pypilot/sensors.py
@@ -7,7 +7,7 @@
 # License as published by the Free Software Foundation; either
 # version 3 of the License, or (at your option) any later version.  
 
-import math, datetime
+import math
 
 from client import *
 from values import *
@@ -16,7 +16,6 @@ from resolv import resolv
 from gpsd import gpsd
 from gps_filter import *
 
-import quaternion
 
 # favor lower priority sources
 source_priority = {'gpsd' : 1, 'servo': 1, 'serial' : 2, 'tcp' : 3,
@@ -290,7 +289,7 @@ class Water(Sensor):
 
     def update(self, data):
         t = time.monotonic()
-        if not 'speed' in data:
+        if 'speed' not in data:
             return False
 
         self.speed.set(data['speed'])
@@ -414,7 +413,7 @@ class Sensors(object):
             self.lostsensor(self.gps)
             
     def write(self, sensor, data, source):
-        if not sensor in self.sensors:
+        if sensor not in self.sensors:
             print(_('unknown data parsed!'), sensor)
             return
         self.sensors[sensor].write(data, source)

--- a/pypilot/serialprobe.py
+++ b/pypilot/serialprobe.py
@@ -5,7 +5,8 @@
 # License as published by the Free Software Foundation; either
 # version 3 of the License, or (at your option) any later version.  
 
-import sys, os, time
+import os
+import time
 import pyjson
 
 pypilot_dir = os.getenv('HOME') + '/.pypilot/'
@@ -26,7 +27,7 @@ def read_config(filename, fail):
                 devices.append(device.strip())
             f.close()
             return devices
-        except Exception as e:
+        except Exception:
             print(_('error reading'), pypilot_dir + filename)
     return fail
 
@@ -60,7 +61,7 @@ def read_last_working_devices():
                     lastdevice = pyjson.loads(file.readline().rstrip())
                     file.close()
                     # ensure lastdevice defines path and baud here
-                    if not name in probes:
+                    if name not in probes:
                         new_probe(name)
                     probes[name]['lastworking'] = lastdevice[0], lastdevice[1]
                 except:
@@ -220,12 +221,12 @@ def enumerate_devices():
     debug('serialprobe scan', scanned_devices)
     # remove devices not scanned
     for device in list(devices):
-        if not device in scanned_devices:
+        if device not in scanned_devices:
             del devices[device]
 
     # add new devices and set the time the device was added
     for device in scanned_devices:
-        if not device in devices:
+        if device not in devices:
             devices[device] = scanned_devices[device]
             devices[device]['time'] = t0
     return True
@@ -246,10 +247,10 @@ def probe(name, bauds, timeout=5):
         # relinquish any probes that are assigned to devices that no longer exist
         for n, probe in probes.items():
             device = probe['device']
-            if device and not device in devices:
+            if device and device not in devices:
                 probe['device'] = False
     
-    if not name in probes:
+    if name not in probes:
         new_probe(name)
     probe = probes[name]
 

--- a/pypilot/server.py
+++ b/pypilot/server.py
@@ -7,23 +7,32 @@
 # License as published by the Free Software Foundation; either
 # version 3 of the License, or (at your option) any later version.  
 
-import select, socket, time
-import sys, os, heapq
+import select
+import socket
+import time
+import sys
+import os
+import heapq
 
-import numbers
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-import gettext_loader
+import gettext_loader  # noqa: F401 — installs `_` as a builtin via side effect
 import pyjson
 from bufferedsocket import LineBufferedNonBlockingSocket
 from nonblockingpipe import NonBlockingPipe
-
-DEFAULT_PORT = 23322
 from zeroconf_service import zeroconf
-max_connections = 30
-configfilepath = os.getenv('HOME') + '/.pypilot/'
+
+# Runtime configuration. All of these can be overridden via PYPILOT_*
+# environment variables so deployments can pick different ports or
+# config directories without editing source.
+DEFAULT_PORT = int(os.getenv('PYPILOT_PORT', '23322'))
+max_connections = int(os.getenv('PYPILOT_MAX_CONNECTIONS', '30'))
+configfilepath = os.getenv('PYPILOT_CONFIG_DIR',
+                           os.path.expanduser('~/.pypilot/'))
+if not configfilepath.endswith('/'):
+    configfilepath += '/'
 configfilename = 'pypilot.conf'
-server_persistent_period = 60 # store data every 60 seconds
-use_multiprocessing = True # run server in a separate process
+server_persistent_period = int(os.getenv('PYPILOT_PERSIST_PERIOD', '60'))
+use_multiprocessing = os.getenv('PYPILOT_MULTIPROCESSING', '1') != '0'
 
 class Watch(object):
     def __init__(self, value, connection, period):
@@ -76,7 +85,7 @@ class pypilotValue(object):
                 try:
                     pyjson.loads(data) # validate data
                     self.connection.write(msg)
-                except Exception as e:
+                except Exception:
                     print('failed to load ', msg)
                 self.msg = None
             else: # inform key can not be set arbitrarily
@@ -168,7 +177,7 @@ class ServerWatch(pypilotValue):
         watches = pyjson.loads(data)
         values = self.server_values.values
         for name in watches:
-            if not name in values:
+            if name not in values:
                 # watching value not yet registered, add it so we can watch it
                 values[name] = pypilotValue(self.server_values, name)
             values[name].watch(connection, watches[name])
@@ -183,7 +192,7 @@ class ServerUDP(pypilotValue):
         try:
             name, data = msg.rstrip().split('=', 1)
             self.msg = pyjson.loads(data)
-            if not (self.msg is False) and self.msg < 1024 or self.msg > 65535:
+            if self.msg is not False and self.msg < 1024 or self.msg > 65535:
                 raise Exception('port out of range')
         except Exception as e:
             connection.write('error=invalid udp_port:' + msg + e + '\n')
@@ -237,7 +246,7 @@ class ServerProfiles(pypilotValue):
             profile = self.server_values.values['profile']
 
             # if current profile is removed switch to first profile
-            if not profile.profile in self.profiles:
+            if profile.profile not in self.profiles:
                 profile.set('profile="' + profiles[0] + '"\n', False)
                 
         except Exception as e:
@@ -278,10 +287,10 @@ class ServerProfile(pypilotValue):
         persistent_values = self.server_values.persistent_values
         persistent_data = self.server_values.persistent_data
 
-        if not self.profile in persistent_data:
+        if self.profile not in persistent_data:
             persistent_data[self.profile] = {}
         prev = persistent_data[self.profile]
-        if not strprofile in persistent_data:
+        if strprofile not in persistent_data:
             persistent_data[strprofile] = {}
         data = persistent_data[strprofile]
         for name, value in persistent_values.items():
@@ -289,11 +298,11 @@ class ServerProfile(pypilotValue):
                 continue
             #print("set profile", name, value, value.msg, prev[name])
             if value.msg:  # the msg may still be invalidated from a previous set
-                if not name in prev or prev[name] != value.msg:
+                if name not in prev or prev[name] != value.msg:
                     prev[name] = value.msg
                 self.server_values.need_store = True # ensure we store c
 
-            if not name in data:
+            if name not in data:
                 vmsg = value.get_msg()  # add this value to profile copying it from previous profile
                 if vmsg:
                     data[name] = vmsg
@@ -400,7 +409,7 @@ class ServerValues(pypilotValue):
             if info.get('persistent'):
                 # when a persistant value is missing from pypilot.conf
                 value.calculate_watch_period()
-                if not name in self.persistent_values:
+                if name not in self.persistent_values:
                     self.persistent_values[name] = value
 
             if info.get('profiled'):
@@ -422,7 +431,7 @@ class ServerValues(pypilotValue):
             return # silently ignore empty line used to poll connection if no data
         #print("SERvER HANdLE request", msg)
         name, data = msg.split('=', 1)
-        if not name in self.values:
+        if name not in self.values:
             connection.write('error=invalid unknown value: ' + name + '\n')
             return
 
@@ -441,7 +450,7 @@ class ServerValues(pypilotValue):
                 break
             try:
                 name, data = line.rstrip().split('=', 1)
-            except Exception as e:
+            except Exception:
                 print('failed to split ' + filename + ' line ', linei)
                 continue
             if name[0] == '[' and data[-1] == ']': # new section
@@ -454,7 +463,7 @@ class ServerValues(pypilotValue):
                     continue
                 
                 profile = data[1:-2].replace('"', '')
-                if not profile in self.persistent_data:
+                if profile not in self.persistent_data:
                     self.persistent_data[profile] = {}
                 continue
 
@@ -558,14 +567,14 @@ class ServerValues(pypilotValue):
                 continue
             if value.info.get('profiled'):
                 profile = self.values['profile'].profile
-                if not profile in self.persistent_data:
+                if profile not in self.persistent_data:
                     self.persistent_data[profile] = {}
             else:
                 profile = None
 
             data = self.persistent_data[profile]
             msg = value.get_msg()
-            if msg and (not name in data or msg != data[name]):
+            if msg and (name not in data or msg != data[name]):
                 #print("need store, changed", name, data[name].rstrip(), msg.rstrip())
                 data[name] = msg
                 self.need_store = name
@@ -730,7 +739,7 @@ class pypilotServer(object):
                 self.fd_to_connection[fd] = socket
                 self.poller.register(fd, select.POLLIN)
             elif flag & (select.POLLHUP | select.POLLERR | select.POLLNVAL):
-                if not connection in self.sockets:
+                if connection not in self.sockets:
                     print(_('internal pipe closed, server exiting'))
                     exit(0)
                 self.RemoveSocket(connection)

--- a/pypilot/servo.py
+++ b/pypilot/servo.py
@@ -7,8 +7,11 @@
 # License as published by the Free Software Foundation; either
 # version 3 of the License, or (at your option) any later version.  
 
-import os, math, sys, time
-import select, serial
+import os
+import math
+import sys
+import time
+import serial
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
@@ -216,7 +219,7 @@ class MinRangeSetting(RangeSetting):
 
     def set(self, value):
         if value < self.minvalue.value:
-            value = self.minvalue.value;
+            value = self.minvalue.value
         super(MinRangeSetting, self).set(value)
 
 class MaxRangeSetting(RangeSetting):
@@ -770,7 +773,7 @@ def test(device_path):
     while True:
         try:
             device = serial.Serial(device_path, 38400)
-            break;
+            break
         except Exception as e:
             print(e)
             time.sleep(.5)

--- a/pypilot/servo_calibration.py
+++ b/pypilot/servo_calibration.py
@@ -5,9 +5,10 @@
 # License as published by the Free Software Foundation; either
 # version 3 of the License, or (at your option) any later version.  
 
-import time, sys, os
+import time
+import sys
+import os
 import json
-from pypilot.client import pypilotClient
 from servo import *
 
 import threading
@@ -448,14 +449,14 @@ class ServoCalibration(object):
             self.thread.exit()
 
 def round_any(x, n):
-    if type(x) == type({}):
+    if isinstance(x, dict):
         r = {}
         for v in x:
             r[v] = round_any(x[v], n)
         return r
-    elif type(x) == type([]):
+    elif isinstance(x, list):
         return map(lambda v : round_any(v, n), x)
-    elif type(x) == type(0.0):
+    elif isinstance(x, float):
         return round(x, n)
     else:
         return x

--- a/pypilot/signalk.py
+++ b/pypilot/signalk.py
@@ -7,7 +7,10 @@
 # License as published by the Free Software Foundation; either
 # version 3 of the License, or (at your option) any later version.  
 
-import time, socket, multiprocessing, os
+import time
+import socket
+import multiprocessing
+import os
 from nonblockingpipe import NonBlockingPipe
 import pyjson
 from client import pypilotClient
@@ -72,7 +75,7 @@ class ZeroConfProcess(multiprocessing.Process):
         if 'swname' in properties and properties['swname'] == 'signalk-server':
             try:
                 host_port = socket.inet_ntoa(info.addresses[0]) + ':' + str(info.port)
-            except Exception as e:
+            except Exception:
                 host_port = socket.inet_ntoa(info.address) + ':' + str(info.port)
             self.name_type = name, type
             self.pipe[1].send(host_port)
@@ -86,7 +89,7 @@ class ZeroConfProcess(multiprocessing.Process):
                 if warned:
                     print('signalk:' + _('succeeded') + ' import zeroconf')
                 break
-            except Exception as e:
+            except Exception:
                 if not warned:
                     print('signalk: ' + _('failed to') + ' import zeroconf, ' + _('autodetection not possible'))
                     print(_('try') + ' pip3 install zeroconf' + _('or') + ' apt install python3-zeroconf')
@@ -147,7 +150,7 @@ class signalk(object):
             self.token = f.read()
             print('signalk' + _('read token'), self.token)
             f.close()
-        except Exception as e:
+        except Exception:
             print('signalk ' + _('failed to read token'), token_path)
             self.invalid_token()
 
@@ -162,7 +165,7 @@ class signalk(object):
         for sensor in signalk_table:
             for signalk_path_conversion, pypilot_path in signalk_table[sensor].items():
                 signalk_path, signalk_conversion = signalk_path_conversion
-                if type(pypilot_path) == type({}): # single path translates to multiple pypilot
+                if isinstance(pypilot_path, dict): # single path translates to multiple pypilot
                     self.last_values_keys[signalk_path] = {}
 
         self.enabled = self.client.register(BooleanProperty('signalk.enabled', True, persistent=True))
@@ -219,7 +222,7 @@ class signalk(object):
                                 f = open(token_path, 'w')
                                 f.write(self.token)
                                 f.close()
-                            except Exception as e:
+                            except Exception:
                                 print('signalk ' + _('failed to store token'), token_path)
                     else:
                         self.uid.set('pypilot') # re-enumerate a new ID
@@ -406,7 +409,7 @@ class signalk(object):
         while True:
             try:
                 msg = self.ws.recv()
-            except Exception as e:
+            except Exception:
                 break
 
             if not msg:
@@ -431,16 +434,16 @@ class signalk(object):
                 data = {}
                 for signalk_path_conversion, pypilot_path in sensor_table.items():
                     signalk_path, signalk_conversion = signalk_path_conversion
-                    if signalk_path in values and not values[signalk_path] is None:
+                    if signalk_path in values and values[signalk_path] is not None:
                         try:
-                            if not 'timestamp'in data and signalk_path in self.signalk_last_msg_time:
+                            if 'timestamp' not in data and signalk_path in self.signalk_last_msg_time:
                                 ts = time.strptime(self.signalk_last_msg_time[signalk_path], '%Y-%m-%dT%H:%M:%S.%fZ')
                                 data['timestamp'] = time.mktime(ts)
 
                             value = values[signalk_path]
-                            if type(pypilot_path) == dict: # single path translates to multiple pypilot
+                            if isinstance(pypilot_path, dict): # single path translates to multiple pypilot
                                 for signalk_key, pypilot_key in pypilot_path.items():
-                                    if not value[signalk_key] is None:
+                                    if value[signalk_key] is not None:
                                         data[pypilot_key] = value[signalk_key] / signalk_conversion
                             else:
                                 data[pypilot_path] = value / signalk_conversion
@@ -467,7 +470,7 @@ class signalk(object):
         # see if we can produce any signalk output from the data we have read
         updates = []
         for sensor in signalk_table:
-            if sensor != 'imu' and (not sensor in self.last_sources or\
+            if sensor != 'imu' and (sensor not in self.last_sources or\
                                     source_priority[self.last_sources[sensor]]>=signalk_priority):
                 #debug('signalk skip send from priority', sensor)
                 continue
@@ -477,7 +480,7 @@ class signalk(object):
 
             for signalk_path_conversion, pypilot_path in signalk_table[sensor].items():
                 signalk_path, signalk_conversion = signalk_path_conversion
-                if type(pypilot_path) == dict: # single path translates to multiple pypilot
+                if isinstance(pypilot_path, dict): # single path translates to multiple pypilot
                     keys = self.last_values_keys[signalk_path]
                     # store keys we need for this signalk path in dictionary                    
                     for signalk_key, pypilot_key in pypilot_path.items():
@@ -494,7 +497,7 @@ class signalk(object):
                     v = {}
                     for signalk_key, pypilot_key in pypilot_path.items():
                         key = sensork+'.'+pypilot_key
-                        if not key in keys:
+                        if key not in keys:
                             break
                         v[signalk_key] = keys[key]*signalk_conversion
                     else: # we have all the keys required
@@ -553,7 +556,7 @@ class signalk(object):
 
                 if 'timestamp' in update:
                     timestamp = update['timestamp']
-                if not source in self.signalk_values:
+                if source not in self.signalk_values:
                     self.signalk_values[source] = {}
                 if 'values' in update:
                     values = update['values']
@@ -584,7 +587,7 @@ class signalk(object):
             self.client.watch('gps.fix', watch)
         else:
             for signalk_path_conversion, pypilot_path in signalk_table[sensor].items():
-                if type(pypilot_path) == dict:
+                if isinstance(pypilot_path, dict):
                     for signalk_key, pypilot_key in pypilot_path.items():
                         pypilot_path = sensor + '.' + pypilot_key
                         if pypilot_path in self.last_values:

--- a/pypilot/values.py
+++ b/pypilot/values.py
@@ -7,7 +7,8 @@
 # License as published by the Free Software Foundation; either
 # version 3 of the License, or (at your option) any later version.  
 
-import os, time, math
+import time
+import math
 import pyjson
 from resolv import resolv
 
@@ -57,14 +58,14 @@ class JSONValue(Value):
         return pyjson.dumps(self.value)
 
 def round_value(value, fmt):
-    if type(value) == type([]):
+    if isinstance(value, list):
         ret = '['
         if len(value):
             ret += round_value(value[0], fmt)
             for item in value[1:]:
                 ret += ', ' + round_value(item, fmt)
         return ret + ']'
-    elif type(value) == type(False):
+    elif isinstance(value, bool):
         if value:
             return 'true'
         return 'false'
@@ -87,7 +88,7 @@ class StringValue(Value):
         super(StringValue, self).__init__(name, initial, **kwargs)
 
     def get_msg(self):
-        if type(self.value) == type(False):
+        if isinstance(self.value, bool):
             strvalue = 'true' if self.value else 'false'
         else:
             strvalue = '"' + self.value + '"'
@@ -105,7 +106,7 @@ class SensorValue(Value):
 
     def get_msg(self):
         value = self.value
-        if type(value) == type(tuple()):
+        if isinstance(value, tuple):
             value = list(value)
         return round_value(value, self.fmt)
 

--- a/pypilot/zeroconf_service.py
+++ b/pypilot/zeroconf_service.py
@@ -9,7 +9,11 @@
 
 # make it not blocking with the main server
 
-import socket, struct, fcntl, time, os
+import socket
+import struct
+import fcntl
+import time
+import os
 import threading
 
 DEFAULT_PORT = 23322
@@ -31,7 +35,7 @@ def get_local_addresses():
                     if 'addr' in i:
                         addresses.append(i['addr'])
             return addresses
-        except Exception as e:
+        except Exception:
             #print('zeroconf service fallback to socket address')
             retries -= 1
         

--- a/setup.py
+++ b/setup.py
@@ -126,11 +126,17 @@ setup (name = 'pypilot',
        license = 'GPLv3',
        author="Sean D'Epagnier",
        url='http://pypilot.org/',
+       python_requires='>=3.6',
        packages=packages,
        package_dir=package_dirs,
        ext_modules = ext_modules,
        package_data=package_data,
        cmdclass={'install': build_ext_first},
+       extras_require={
+           # Optional performance dep; pypilot.pyjson falls back to the
+           # stdlib json module if ujson is not importable.
+           'performance': ['ujson>=1.35'],
+       },
        entry_points={
            'console_scripts': [
                'pypilot=pypilot.autopilot:main',


### PR DESCRIPTION
## Summary

Opportunistic cleanup and packaging improvements discovered while doing the SignalK / safety review. Purely cosmetic & mechanical — no behaviour changes. Independent of #276 and #277.

## Changes

**Packaging**
- `setup.py`: declare `python_requires='>=3.6'` so installs fail fast on unsupported interpreters.
- `setup.py`: `extras_require={'performance': ['ujson>=1.35']}` so the optional ujson dep is declared.
- `pypilot/pyjson.py`: silent fallback to stdlib `json` when ujson is absent (it's an extra now).
- `pypilot/failedimports.py`: drop `from __future__ import print_function` and the py2 re-exec path. `python_requires` guarantees py3.

**Server configuration**
- `pypilot/server.py`: `PYPILOT_PORT`, `PYPILOT_MAX_CONNECTIONS`, `PYPILOT_CONFIG_DIR`, `PYPILOT_PERSIST_PERIOD`, `PYPILOT_MULTIPROCESSING` env-var overrides. No change if unset.

**Mechanical lint**
- `ruff check --fix` across `pypilot/`: split multi-imports (E401), drop unused imports (F401), drop unused `as e` bindings, and a few E713/E714/E703 cleanups across 33 files.
- 27 instances of `type(x) == type({...})` rewritten to `isinstance(x, ...)` (and the `!=` form to `not isinstance`) across `signalk.py`, `values.py`, `client.py`, `nmea.py`, `rudder.py`, and others.
- Restored `import gettext_loader` (with `noqa: F401`) in `server.py` and `client.py`: `ruff` removed it, but it's imported for side effect (installs `_` as a builtin).

## Test plan
- [ ] `python3 -c "import ast; ..."` parses all files
- [ ] `ruff check pypilot/` shows reduction vs. master (~155 fewer findings)
- [ ] Install on a test Pi and confirm `pypilot`, `pypilot_web` services still start; no NameError for `_`
- [ ] Set `PYPILOT_PORT=12345` and confirm server binds to that port
- [ ] Install with and without ujson; confirm no warning when ujson is absent