### PR TITLE
web: import Markup from markupsafe (Flask 2.3+ compatibility)

### DIFF
--- a/web/web.py
+++ b/web/web.py
@@ -7,7 +7,9 @@
 # version 3 of the License, or (at your option) any later version.  
 
 import sys, os
-from flask import Flask, render_template, session, request, Markup
+from flask import Flask, render_template, session, request
+# Flask 2.3+ removed the `Markup` re-export; import from its real home.
+from markupsafe import Markup
 
 from flask_socketio import SocketIO, Namespace, emit, join_room, leave_room, \
     close_room, rooms, disconnect


### PR DESCRIPTION
## Summary

`pypilot_web` crashes on startup on any system running Flask 2.3+ (most current Debian/Raspberry Pi OS installs) with:

```
ImportError: cannot import name 'Markup' from 'flask' (/usr/lib/python3/dist-packages/flask/__init__.py)
```

Flask 2.3 deprecated and Flask 3.0 removed the `Markup` re-export. `markupsafe` has always been the actual home of `Markup`; Flask just re-exported it. Switching to the canonical import fixes the crash without changing semantics.

Caught while installing a patched pypilot on a Raspberry Pi with the current apt `python3-flask 3.1.1`.

## Test plan
- [ ] `python3 -c "from markupsafe import Markup; print(Markup)"` succeeds
- [ ] `systemctl restart pypilot_web` followed by `systemctl status pypilot_web` shows `active (running)` and the web UI loads