### PR TITLE
Packaging follow-ons: silent ujson fallback, drop py2 re-exec

### DIFF
--- a/pypilot/failedimports.py
+++ b/pypilot/failedimports.py
@@ -10,14 +10,7 @@
 
 print(_('pypilot failed to import required modules.  Did you forget to run sudo python3 setup.py install?'))
 
-import sys
-
-if sys.version_info[0] < 3:
-    print('pypilot requires python version 3.  python version is', sys.version)
-    print('I will now attempt to re-run the command using python 3')
-    cmd = 'python3 '
-    for arg in sys.argv:
-        cmd += arg + ' '
-    import os
-    os.system(cmd)
+# pyproject.toml declares requires-python>=3.9, so reaching this module
+# guarantees we are already on Python 3. The previous py2 re-exec branch
+# is unreachable and has been removed.
 exit(1)

--- a/pypilot/pyjson.py
+++ b/pypilot/pyjson.py
@@ -12,12 +12,12 @@ try:
 except ImportError:
     from . import gettext_loader
 
+# ujson is declared in pyproject.toml under the `optimize` extra. When it
+# isn't installed, the stdlib json module is the documented fallback, so
+# the warning print on ImportError has been dropped.
 try:
-    import ujson
+    import ujson as _json
+except ImportError:
+    import json as _json
 
-    loads, dumps = ujson.loads, ujson.dumps
-except Exception as e:
-    print(_("WARNING: python ujson library failed, parsing will consume more cpu"), e)
-    import json
-
-    loads, dumps = json.loads, json.dumps
+loads, dumps = _json.loads, _json.dumps


### PR DESCRIPTION
Two small follow-ons aligned with the packaging in your `pyproject.toml`. Split out from #278.

## Changes

- **`pypilot/pyjson.py`**: drop the warning print on `ujson` ImportError. `ujson` is declared in `pyproject.toml` under the `optimize` extra, so installs without that extra are an explicit user choice; the stdlib `json` module is the documented fallback, not a degraded mode worth warning about.
- **`pypilot/failedimports.py`**: drop the py2 detection and re-exec block. With `requires-python = ">=3.9"` declared in `pyproject.toml`, that branch is unreachable.

10 insertions, 17 deletions across 2 files. No behaviour change for users on the supported configuration.

## Test plan
- [x] Both files parse
- [x] \`from pypilot.pyjson import loads, dumps\` works on a system without ujson installed (silent fallback to stdlib json)
- [x] No new warnings on import