### PR TITLE
server: PYPILOT_* env-var overrides for runtime configuration

### DIFF
--- a/pypilot/server.py
+++ b/pypilot/server.py
@@ -20,14 +20,21 @@ import pyjson
 from bufferedsocket import LineBufferedNonBlockingSocket
 from nonblockingpipe import NonBlockingPipe
 
-DEFAULT_PORT = 23322
+# Runtime configuration. Each value can be overridden via a PYPILOT_*
+# environment variable so deployments can pick a different port or
+# config directory without editing source. Behaviour with no env vars
+# set is unchanged.
+DEFAULT_PORT = int(os.getenv('PYPILOT_PORT', '23322'))
 from zeroconf_service import zeroconf
 
-max_connections = 30
-configfilepath = os.getenv('HOME') + '/.pypilot/'
+max_connections = int(os.getenv('PYPILOT_MAX_CONNECTIONS', '30'))
+configfilepath = os.getenv('PYPILOT_CONFIG_DIR',
+                           os.path.expanduser('~/.pypilot/'))
+if not configfilepath.endswith('/'):
+    configfilepath += '/'
 configfilename = 'pypilot.conf'
-server_persistent_period = 60 # store data every 60 seconds
-use_multiprocessing = True # run server in a separate process
+server_persistent_period = int(os.getenv('PYPILOT_PERSIST_PERIOD', '60'))
+use_multiprocessing = os.getenv('PYPILOT_MULTIPROCESSING', '1') != '0'
 
 class Watch:
     def __init__(self, value, connection, period):


### PR DESCRIPTION
Allow runtime configuration to be overridden via environment variables, so deployments can run a non-default port or config directory without editing source. Split out from #278.

## Changes (`pypilot/server.py`, 12+/5−)

| Env var                   | Overrides                  | Default     |
|---------------------------|----------------------------|-------------|
| \`PYPILOT_PORT\`            | \`DEFAULT_PORT\`             | 23322       |
| \`PYPILOT_MAX_CONNECTIONS\` | \`max_connections\`          | 30          |
| \`PYPILOT_CONFIG_DIR\`      | \`configfilepath\`           | \`~/.pypilot/\` |
| \`PYPILOT_PERSIST_PERIOD\`  | \`server_persistent_period\` | 60          |
| \`PYPILOT_MULTIPROCESSING\` | \`use_multiprocessing\` (\`0\` disables) | \`1\` (on) |

With none of the env vars set, all defaults match prior behaviour exactly.

## Test plan
- [x] With env unset: \`DEFAULT_PORT=23322\`, \`max_connections=30\`, \`configfilepath=~/.pypilot/\`, \`server_persistent_period=60\`, \`use_multiprocessing=True\`
- [x] With \`PYPILOT_PORT=12345 PYPILOT_MAX_CONNECTIONS=42 PYPILOT_CONFIG_DIR=/tmp/foo PYPILOT_PERSIST_PERIOD=99 PYPILOT_MULTIPROCESSING=0\`: each value picked up
- [ ] On a Pi: confirm \`pypilot\` service still starts with no env vars set