### PR TITLE
web/web.py: resolve merge conflict markers and stale duplicates

### DIFF
--- a/web/web.py
+++ b/web/web.py
@@ -15,8 +15,6 @@ from flask_socketio import SocketIO, Namespace, emit, join_room, leave_room, \
     close_room, rooms, disconnect
 
 from engineio.payload import Payload
-from flask import Flask, Markup, render_template, request
-from flask_socketio import Namespace, SocketIO, emit
 
 Payload.max_decode_packets = 500
 
@@ -63,12 +61,7 @@ app.config['SECRET_KEY'] = 'secret!'
 socketio = SocketIO(app, cors_allowed_origins="*")
 
 try:
-<<<<<<< HEAD
     from flask_babel import Babel
-    babel = Babel(app)
-=======
-    from flask_babel import Babel, gettext
->>>>>>> 1b0041392426038a23d89bb71f74f427c09891c0
 
     LANGUAGES = os.listdir(os.path.dirname(os.path.abspath(__file__)) + '/translations')
     def get_locale():
@@ -79,12 +72,7 @@ try:
         if language == 'default' or language not in LANGUAGES:
             return request.accept_languages.best_match(LANGUAGES)
         return language
-<<<<<<< HEAD
-
-=======
     babel = Babel(app, locale_selector=get_locale)
-    
->>>>>>> 1b0041392426038a23d89bb71f74f427c09891c0
 except Exception as e:
     print('failed to import flask_babel, translations not possible!!', e)
     def _(x): return x


### PR DESCRIPTION
## Summary

`web/web.py` on master will not parse: three unresolved git conflict marker blocks plus a pair of duplicate import lines were left in the file. This PR resolves the markers in favor of the modern `flask_babel` API and drops the duplicates. Sibling to #284, which moved `Markup` to `markupsafe` in the same import block; this finishes that cleanup by removing the stale duplicate that survived an earlier silent merge.

12 lines removed, 0 added.

## Changes

- `web/web.py:18-19`: drop duplicate `from flask import Flask, Markup, ...` and `from flask_socketio import Namespace, SocketIO, emit`. These are pure subsets of the canonical imports at `web/web.py:11` (now `from flask import Flask, render_template, session, request`, with `Markup` sourced from `markupsafe` per #284) and `web/web.py:14`. No symbol is lost.
- `web/web.py:63-75`: resolve three `<<<<<<< / ======= / >>>>>>> 1b00413...` blocks around the `flask_babel` init. Kept `from flask_babel import Babel` (the unused `gettext` from the other side was confirmed unreferenced via grep) and the modern `Babel(app, locale_selector=get_locale)` constructor form. The surrounding broad `except Exception` translation fallback is unchanged.

## Test plan

- [x] `python -c "import ast; ast.parse(open('web/web.py').read())"` returns OK (was: `SyntaxError` on the conflict markers).
- [x] Whole-tree `ruff check`: 581 -> 544 errors. The 37 that disappeared were all cascading parse errors downstream of the markers; no rule was suppressed.
- [x] `ruff check web/web.py`: previously bailed with a syntax error, now reports 8 pre-existing issues (unused imports, bare excepts, etc.) untouched by this PR. Happy to clean those up in a separate mechanical sweep if useful.
- [x] Smoke import (`python -c "import sys; sys.path.insert(0, 'web'); import web"`) gets past the import block on:
  - Pi OS Trixie, flask 3.x + flask-babel 4.1.0: clean.
  - Pi OS Bookworm, flask 2.2.2 + flask-babel 2.0.0: the `Babel(app, locale_selector=...)` constructor signature is not supported on that older flask-babel and raises `TypeError`, which falls into the existing broad `except Exception as e` block. Translations are silently disabled and the app still starts. This matches the file's existing intent for that fallback.
- [ ] On a Pi: confirm the web UI still loads and `/?language=...` still selects translations on a Trixie install.

## Note on a separate latent bug (not fixed here)

While reading the surrounding block: in the success path of the `flask_babel` `try`, the name `_` is only bound at module scope in the `except` branch. `web/web.py:117` references `_(...)` inside an exception handler in the `/log/<name>` route. If `flask_babel` imports successfully *and* that route's exception path fires, it would `NameError`. Pre-existing, out of scope for this PR; flagging here so it isn't lost. Happy to send a small follow-up if you'd like.