### PR TITLE
web/web.py: bind `_` in flask_babel success path, drop duplicate imports

### DIFF
--- a/web/web.py
+++ b/web/web.py
@@ -15,8 +15,6 @@ from flask_socketio import SocketIO, Namespace, emit, join_room, leave_room, \
     close_room, rooms, disconnect
 
 from engineio.payload import Payload
-from flask import Flask, render_template, request
-from flask_socketio import Namespace, SocketIO, emit
 
 Payload.max_decode_packets = 500
 
@@ -76,7 +74,8 @@ try:
         return language
 
     babel = Babel(app, locale_selector=get_locale)
-    
+    _ = gettext
+
 except Exception as e:
     print('failed to import flask_babel, translations not possible!!', e)
     def _(x): return x


### PR DESCRIPTION
## Summary

Small follow-up to #286 (closed) and the manual conflict resolution in `ed271fd`. Two unrelated, mechanical fixes in `web/web.py`. 5 lines touched: 2 added, 3 removed.

## Changes

### 1. Bind `_` in the `flask_babel` success path

`web/web.py:65-85` is a `try/except` around `flask_babel`. The `except` branch defines a no-op fallback (`def _(x): return x`) and registers it as a Jinja global. The success branch imports `gettext` but never binds `_`, so `_` exists at module scope **only when `flask_babel` import fails.**

`web/web.py:109` references `_(...)` in Python code, inside the exception handler of the `/log/<name>` route:

```python
except Exception as e:
    log = _('failed to read log file') + ' "' + name + '": ' + str(e)
```

If `flask_babel` imports successfully (the normal case on current dependencies) **and** that route's exception path fires (e.g. missing log file), the handler raises `NameError: name '_' is not defined` and crashes the request instead of returning the friendly error string.

Fix: bind `_ = gettext` next to `babel = Babel(app, locale_selector=get_locale)` so the name is available in either branch. Templates already get `_` via Flask-Babel's Jinja extension on the success path, so no `app.jinja_env.globals.update(...)` mirror is needed there.

### 2. Drop two duplicate import lines

`web/web.py:18-19` (post-`ed271fd`) still carries:

```python
from flask import Flask, render_template, request
from flask_socketio import Namespace, SocketIO, emit
```

Both are pure subsets of the canonical imports five lines above:

- `web/web.py:11`: `from flask import Flask, render_template, session, request`
- `web/web.py:14-15`: `from flask_socketio import SocketIO, Namespace, emit, join_room, leave_room, close_room, rooms, disconnect`

No symbol is lost. These were leftovers from the same merge that produced the conflict markers `ed271fd` resolved.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('web/web.py').read())"` returns OK.
- [x] `ruff check web/web.py`: 16 errors before -> 8 after. The 8 that disappeared are the redefinition / unused-import lints on the duplicate lines this PR removes. The remaining 8 are pre-existing and out of scope (unused `session`, `Markup`, `render_template`, `rooms`, `disconnect`; an unused local `x` in `background_thread`; one I001 import-ordering nit).
- [x] Constructed-failure smoke: with `flask_babel` available, hit `/log/does-not-exist`. Before this PR: `NameError` in the except handler. After: returns the expected `failed to read log file "does-not-exist": ...` plain-text response.
- [ ] On a Pi: load the web UI and confirm `/?language=...` still selects translations on a Trixie install (no behavior change expected, but worth a sanity click).

## Note

The remaining 8 ruff issues in this file are mechanical and easy to clear in a separate sweep if useful. Happy to send that as its own small PR if you'd like, or leave it.