### PR TITLE
zeroconf: skip down/loopback interfaces to stop registration leak

### DIFF
--- a/pypilot/zeroconf_service.py
+++ b/pypilot/zeroconf_service.py
@@ -23,6 +23,16 @@ retries = 0
 
 # creating a socket is somehow slow...
 zerosocket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+def _interface_is_up(name):
+    # skip loopback and down interfaces: Zeroconf registration on these fails,
+    # leaks instances every 60s, and eventually breaks the network stack (#272)
+    try:
+        with open('/sys/class/net/' + name + '/operstate') as f:
+            return f.read().strip() == 'up'
+    except OSError:
+        return False
+
 def get_local_addresses():
     global retries
     addresses = []
@@ -30,6 +40,8 @@ def get_local_addresses():
         try:
             from netifaces import ifaddresses, interfaces
             for interface in interfaces():
+                if not _interface_is_up(interface):
+                    continue
                 addrs = ifaddresses(interface)
                 for i in addrs:
                     if 'addr' in i:
@@ -39,7 +51,7 @@ def get_local_addresses():
             #print('zeroconf service fallback to socket address')
             retries -= 1
 
-    interfaces = os.listdir('/sys/class/net')
+    interfaces = [i for i in os.listdir('/sys/class/net') if _interface_is_up(i)]
     for interface in interfaces:
         try:
             addresses.append((interface, socket.inet_ntoa(fcntl.ioctl(


### PR DESCRIPTION
Fixes #272.

`get_local_addresses()` returned every entry under `/sys/class/net`, including loopback and administratively-down interfaces. Zeroconf registration fails on those (no multicast on `lo`; stale IPs on down interfaces). The exception handler in `zeroconf.run()` resets `addresses = []`, so on every 60s tick the `i != addresses` comparison trips, the working registrations are torn down, and the whole set is recreated. Over hours the accumulated Zeroconf instances exhaust the kernel network stack: motamman reported all cloudflared QUIC tunnels and SignalK dying together after ~10h.

Fix: filter both the netifaces path and the ioctl path through a small helper that requires `/sys/class/net/<name>/operstate == 'up'`. That excludes loopback (`operstate=unknown`) and down interfaces (`operstate=down`) up front, so the failing-registration exception path no longer fires every cycle.

Verified on a live Pi with mixed interfaces: `lo`, `eth0` (cable out), and `wwan0` (no SIM) are now skipped; `wlan0` still registers. Filter matches the refined proposal in the issue thread, which the maintainer indicated they wanted to merge.

The exception handler in `zeroconf.run()` that resets `addresses = []` on a register failure is left as-is: with this filter the path no longer fires for the reported triggers, and tightening its retention/retry policy is a separate design call.