### PR TITLE
web: add missing gettext_helper and restore dropped Flask imports

### DIFF
--- a/web/gettext_helper.py
+++ b/web/gettext_helper.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+#   Copyright (C) 2026 Sean D'Epagnier
+#
+# This Program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+
+# Lightweight gettext wrapper that replaces flask_babel for pypilot's web UIs.
+
+import gettext as _gettext
+import os
+
+from flask import has_request_context, request
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_LOCALE_DIR = os.path.join(_THIS_DIR, 'translations')
+_DOMAIN = 'messages'
+
+try:
+    LANGUAGES = sorted(os.listdir(_LOCALE_DIR))
+except OSError:
+    LANGUAGES = []
+
+_translations = {}
+for _lang in LANGUAGES:
+    try:
+        _translations[_lang] = _gettext.translation(
+            _DOMAIN, _LOCALE_DIR, languages=[_lang], fallback=False)
+    except OSError:
+        # .mo not compiled for this language; fall through to NullTranslations
+        pass
+
+_null = _gettext.NullTranslations()
+
+
+def _load_pot_static_strings():
+    # Collect msgids that appear under "#: static" reference blocks in
+    # pypilot_web.pot, mirroring the loop that lived inline in web.py.
+    # Used by the index template to feed static strings to the JS layer.
+    out = []
+    path = os.path.join(_THIS_DIR, 'pypilot_web.pot')
+    try:
+        with open(path) as f:
+            in_static = False
+            for line in f:
+                if line.startswith('#: static'):
+                    in_static = True
+                elif not line.strip():
+                    in_static = False
+                elif in_static and line.startswith('msgid "'):
+                    s = line.strip()[7:-1]
+                    if s:
+                        out.append(s)
+    except OSError:
+        pass
+    return out
+
+
+translations = _load_pot_static_strings()
+
+
+def _pick_translation(config):
+    lang = None
+    if config and config.get('language') and config['language'] != 'default':
+        lang = config['language']
+    elif has_request_context():
+        lang = request.accept_languages.best_match(LANGUAGES)
+    return _translations.get(lang, _null)
+
+
+def load(app, config=None):
+    # Install a request-scoped `_` translator on the Flask app and return
+    # it so the caller can also bind it at module scope (web.py uses
+    # bare `_("...")` calls in route handlers).
+    def _(s):
+        return _pick_translation(config).gettext(s)
+    app.jinja_env.globals.update(_=_)
+    return _

--- a/web/web.py
+++ b/web/web.py
@@ -6,11 +6,13 @@
 # License as published by the Free Software Foundation; either
 # version 3 of the License, or (at your option) any later version.
 
-import sys
 import os
+import sys
 
-from markupsafe import Markup
 from engineio.payload import Payload
+from flask import Flask, render_template, request
+from flask_socketio import Namespace, SocketIO, emit
+from markupsafe import Markup
 
 Payload.max_decode_packets = 500
 
@@ -54,7 +56,7 @@ print('using port', pypilot_web_port)
 app = Flask(__name__)
 app.config['SECRET_KEY'] = 'secret!'
 socketio = SocketIO(app, cors_allowed_origins="*")
-gettext_helper.load(app, config)
+_ = gettext_helper.load(app, config)
 
 @app.route('/logs')
 def logs():


### PR DESCRIPTION
Restores `pypilot_web` and `pypilot_hat` to runnable state on master.

Commit f1f2e87 ("improve translations and eliminate babel and flask_babel dependency") rewrote `web/web.py` and `hat/web.py` to delegate translation handling to a new `gettext_helper` module, but the module file was never committed. The follow-up merge 32a8bdd also dropped the `from flask import Flask, render_template, request` and `from flask_socketio import SocketIO, Namespace, emit` imports from `web/web.py`. Master is currently dead on arrival:

- `pypilot_web`: NameError on `Flask` at line 55 (and `ImportError: No module named 'gettext_helper'` at line 19 first).
- `pypilot_hat`: `ImportError: cannot import name 'gettext_helper' from 'pypilot.web'` at `hat/web.py:17`.

Changes:

- New `web/gettext_helper.py`: stdlib-gettext replacement for the old flask_babel dispatcher. Exposes `LANGUAGES`, `translations` (the JS-side static-string list previously extracted inline from `pypilot_web.pot`), and `load(app, config=None)` which installs `_` on the Flask Jinja env and returns the translator so callers can also bind it at module scope.
- `web/web.py`: restore the dropped flask + flask_socketio imports. Move `import gettext_helper` to after the `sys.path.append` so the import resolves both when running from source and via the `pypilot_web` entry point. Bind `_ = gettext_helper.load(app, config)` so the `_('failed to read log file')` call in the `/log` route resolves at module scope.

Verified locally: both modules load under stubbed Flask, `translations` matches the pre-f1f2e87 inline output (15 strings), and the `from pypilot.web import gettext_helper` form used by `hat/web.py` resolves. Ruff is clean on the changed files (one pre-existing `F841 x = 0` finding on line 177 is left for a separate cleanup PR).

Out of scope: removing `flask-babel` from the `web` and `hat` extras in `pyproject.toml`. The import is gone but the declaration is harmless until a packaging-focused PR.
