### PR TITLE
home: resolve ~/.pypilot via os.path.expanduser (fixes #264)

### DIFF
--- a/hat/arduino.py
+++ b/hat/arduino.py
@@ -60,7 +60,7 @@ def update_firmware(config):
     # determine firmware version we have on disk
     firmware = False
     try:
-        path = os.getenv('HOME') + '/.pypilot/firmware'
+        path = os.path.expanduser('~') + '/.pypilot/firmware'
         for filename in os.listdir(path):
             print("FILE", filename)
             if filename.startswith('hat_') and filename.endswith('.hex'):

--- a/hat/font.py
+++ b/hat/font.py
@@ -23,7 +23,7 @@ except ImportError:
     import os
 
     from pypilot.hat.ugfx import ugfx
-    fontpath = os.path.abspath(os.getenv('HOME') + '/.pypilot/ugfxfonts/') + '/'
+    fontpath = os.path.abspath(os.path.expanduser('~') + '/.pypilot/ugfxfonts/') + '/'
 
     if not os.path.exists(fontpath):
         os.makedirs(fontpath)

--- a/hat/hat.py
+++ b/hat/hat.py
@@ -346,7 +346,7 @@ class Hat:
                        'arduino.nmea.in': False, 'arduino.nmea.out': False,
                        'arduino.nmea.baud': 4800,
                        'lcd': {}}
-        self.configfilename = os.getenv('HOME') + '/.pypilot/hat.conf'
+        self.configfilename = os.path.expanduser('~') + '/.pypilot/hat.conf'
 
         # read config
         self.client = False

--- a/pypilot/autopilot.py
+++ b/pypilot/autopilot.py
@@ -21,7 +21,7 @@ import sys
 sys.stdout = io.TextIOWrapper(sys.stdout.detach(), line_buffering=True)
 sys.stderr = io.TextIOWrapper(sys.stderr.detach(), line_buffering=True)
 
-pypilot_dir = os.getenv('HOME') + '/.pypilot/'
+pypilot_dir = os.path.expanduser('~') + '/.pypilot/'
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 import pilots

--- a/pypilot/client.py
+++ b/pypilot/client.py
@@ -152,7 +152,7 @@ class pypilotClient:
 
         config = {}
         try:
-            configfilepath = os.getenv('HOME') + '/.pypilot/'
+            configfilepath = os.path.expanduser('~') + '/.pypilot/'
             if not os.path.exists(configfilepath):
                 os.makedirs(configfilepath)
             if not os.path.isdir(configfilepath):

--- a/pypilot/gpsd.py
+++ b/pypilot/gpsd.py
@@ -146,7 +146,7 @@ class gpsProcess(multiprocessing.Process):
             speed = line.index('speed')
             baud = line.index('baud')
             bps = int(line[speed+6:baud-1])
-            f = open(os.getenv('HOME') + '/.pypilot/gpsd_baud_hint', 'w')
+            f = open(os.path.expanduser('~') + '/.pypilot/gpsd_baud_hint', 'w')
             f.write(str(bps))
             f.close()
         except Exception:

--- a/pypilot/pilots/fuzzy.py
+++ b/pypilot/pilots/fuzzy.py
@@ -19,7 +19,7 @@ from pypilot.values import *
 
 disabled = True
 
-matrixfilepath = os.getenv('HOME') + '/.pypilot/' + 'fuzzy.json'
+matrixfilepath = os.path.expanduser('~') + '/.pypilot/' + 'fuzzy.json'
 
 def fuzzy_defaults(dimensions, c=0):
     if dimensions:

--- a/pypilot/pilots/intellect.py
+++ b/pypilot/pilots/intellect.py
@@ -140,7 +140,7 @@ separate program
 
 
 def model_filename(state):
-  filename = os.getenv('HOME')+'/.pypilot/model_'
+  filename = os.path.expanduser('~')+'/.pypilot/model_'
   for name, value in state.items():
       filename += '_' + str(value)
   return filename

--- a/pypilot/serialprobe.py
+++ b/pypilot/serialprobe.py
@@ -10,7 +10,7 @@ import time
 
 import pyjson
 
-pypilot_dir = os.getenv('HOME') + '/.pypilot/'
+pypilot_dir = os.path.expanduser('~') + '/.pypilot/'
 
 def debug(*args):
     #print(*args)

--- a/pypilot/servo.py
+++ b/pypilot/servo.py
@@ -235,7 +235,7 @@ class MaxRangeSetting(RangeSetting):
         super().set(value)
 
 class Servo:
-    pypilot_dir = os.getenv('HOME') + '/.pypilot/'
+    pypilot_dir = os.path.expanduser('~') + '/.pypilot/'
     calibration_filename = pypilot_dir + 'servocalibration'
 
     def __init__(self, client, sensors):

--- a/pypilot/servo_calibration.py
+++ b/pypilot/servo_calibration.py
@@ -387,7 +387,7 @@ def ServoCalibrationThread(calibration):
     revfit = FitCalibration(rev_calibration)
     cal = {'forward': fwdfit, 'reverse': revfit, 'Min Speed': min_speed, 'Brake Hack': self.brake_hack}
 
-    f = open(os.getenv('HOME') + '/.pypilot/servocalibration', 'w')
+    f = open(os.path.expanduser('~') + '/.pypilot/servocalibration', 'w')
     f.write(json.dumps(cal))
     console('calibration complete')
 

--- a/pypilot/signalk.py
+++ b/pypilot/signalk.py
@@ -62,7 +62,7 @@ signalk_table = {'wind': {('environment.wind.speedApparent', meters_s): 'speed',
                  'water': {('navigation.speedThroughWater', meters_s): 'speed',
                            ('navigation.leewayAngle', radians): 'leeway'}}
 
-token_path = os.getenv('HOME') + '/.pypilot/signalk-token'
+token_path = os.path.expanduser('~') + '/.pypilot/signalk-token'
 
 # Timeout (seconds) for all HTTP requests against the SignalK server. Keep
 # this small because the poll loop is otherwise frozen while it waits.

--- a/web/web.py
+++ b/web/web.py
@@ -22,7 +22,7 @@ import gettext_helper
 import tinypilot
 
 config = {'port': 8000, 'language': 'default'}
-configfilename = os.getenv('HOME')+'/.pypilot/web.conf'
+configfilename = os.path.expanduser('~')+'/.pypilot/web.conf'
 
 try:
     file = open(configfilename)


### PR DESCRIPTION
Fixes #264.

`os.getenv('HOME')` returns `None` when systemd doesn't propagate `HOME` (reporter saw this on Raspbian 13.3 Trixie). The subsequent string concatenation then raises:

```
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```

before any startup output, so `pypilot_web` fails silently. The same idiom appears in 12 other modules (`pypilot/autopilot.py`, `pypilot/client.py`, `pypilot/servo.py`, `pypilot/signalk.py`, `pypilot/gpsd.py`, `pypilot/serialprobe.py`, `pypilot/servo_calibration.py`, `pypilot/pilots/fuzzy.py`, `pypilot/pilots/intellect.py`, `hat/hat.py`, `hat/arduino.py`, `hat/font.py`), all with the same failure mode under the same systemd configurations.

This PR swaps all 13 occurrences to `os.path.expanduser('~')`, which:
- reads `HOME` first (preserving current behavior when set),
- falls back to looking up the current uid in the `pwd` database when `HOME` is absent,
- is stdlib, no new dependency.

Diff is mechanical: one token swap per line. No other behavior change.

Verified locally with `HOME` unset:
- Before: `os.getenv('HOME') + '/.pypilot/web.conf'` raises `TypeError`.
- After:  `os.path.expanduser('~') + '/.pypilot/web.conf'` returns `/home/<user>/.pypilot/web.conf` via the pwd fallback.

Ruff is clean on the changed lines (pre-existing findings in the touched files left for a separate cleanup PR, per the repository's usual scope discipline).
