### PR TITLE
server: persist non-owner writes to writable values (fixes #274)

### DIFF
--- a/pypilot/server.py
+++ b/pypilot/server.py
@@ -87,6 +87,19 @@ class pypilotValue:
                 try:
                     pyjson.loads(data) # validate data
                     self.connection.write(msg)
+                    # mirror writable updates into persistent_data so a restart
+                    # before the owner's next watch tick can't revert (issue #274)
+                    if self.info.get('persistent'):
+                        if self.info.get('profiled'):
+                            profile = self.server_values.values['profile'].profile
+                        else:
+                            profile = None
+                        pdata = self.server_values.persistent_data
+                        if profile not in pdata:
+                            pdata[profile] = {}
+                        if self.name not in pdata[profile] or pdata[profile][self.name] != msg:
+                            pdata[profile][self.name] = msg
+                            self.server_values.need_store = self.name
                 except Exception:
                     print('failed to load ', msg)
                 self.msg = None


### PR DESCRIPTION
Fixes #274.

When a persistent value owned by another process (e.g. `nmea.client` owned by the nmea subprocess) is set via the web UI, `pypilotValue.set` forwards the update to the owner and clears `self.msg = None`. The owner only re-emits the new value on its next watch tick, which is up to `server_persistent_period` (60s by default) away. In the meantime, the periodic `store()` sees `self.msg is None`, falls through its `if msg and ...` guard, and leaves `persistent_data` holding the old value. If the user restarts pypilot before the round-trip completes (e.g. clear `nmea.client` in the web UI, restart immediately to verify), the old value in `pypilot.conf` is reloaded and the connection comes back.

This PR mirrors the validated update into `persistent_data` synchronously in the same code path:

```python
if self.info.get('persistent'):
    ...
    if self.name not in pdata[profile] or pdata[profile][self.name] != msg:
        pdata[profile][self.name] = msg
        self.server_values.need_store = self.name
```

`self.msg = None` is preserved (owner stays authoritative for watcher reads); only the persistence dict is updated. The owner's next re-emit overrides the entry on the next `store()` cycle as before.

Verified red-green with a focused in-process simulation:

- Pre-fix: after a web clear, `persistent_data[None]['nmea.client']` stays at the loaded `'nmea.client="192.168.1.5:10110"\n'` and `need_store` stays `False`.
- Post-fix: `persistent_data[None]['nmea.client']` becomes `'nmea.client=""\n'` and `need_store` is flagged `'nmea.client'`. A second identical set is correctly idempotent (the change-detection guard skips the assignment).

Out of scope but worth a follow-up: the persist-bucket lookup duplicates a near-identical block in `ServerValues.store()` (around line 590). A small `persist_msg(value, msg)` helper on `ServerValues` could share the logic; left for a focused refactor since this PR is targeted at #274.
