### PR TITLE
signalk: skip valueless TXT records and unshadow service name (fixes #266 NoneType.decode)

### DIFF
--- a/pypilot/signalk.py
+++ b/pypilot/signalk.py
@@ -137,11 +137,15 @@ class ZeroConfProcess(multiprocessing.Process):
         if not info:
             return
         properties = {}
-        for name, value in info.properties.items():
+        for k, v in info.properties.items():
+            # zeroconf reports valueless TXT records as (key, None) per RFC 6763;
+            # skip rather than crash on None.decode() (issue #266)
+            if k is None or v is None:
+                continue
             try:
-                properties[name.decode()] = value.decode()
+                properties[k.decode()] = v.decode()
             except Exception as e:
-                print('signalk zeroconf exception', e, name, value)
+                print('signalk zeroconf exception', e, k, v)
 
         if 'swname' in properties and properties['swname'] == 'signalk-server':
             try:


### PR DESCRIPTION
Fixes the first exception reported in #266:

```
signalk zeroconf service add instellen._http._tcp.local. _http._tcp.local.
signalk zeroconf exception 'NoneType' object has no attribute 'decode' b'' None
```

## Bug 1: `None.decode()` on valueless TXT records

`zeroconf` reports an mDNS TXT record without a value (e.g. `key` with no `=value`) as `(key, None)`. RFC 6763 §6.4 explicitly allows this. `ZeroConfProcess.add_service` (signalk.py:140-144) calls `value.decode()` unconditionally, so a valueless TXT entry on *any* `_http._tcp` service the listener sees raises `AttributeError`. The existing `try/except Exception` swallows the crash but prints the exception on every poll, indefinitely.

Skip valueless entries explicitly.

## Bug 2: Loop variable `name` shadowed the outer service name

In the same function, the loop variable was named `name`, shadowing the `name` parameter (the full service identifier like `instellen._http._tcp.local.`). After the loop, `self.name_type = name, type` on line 151 would record the *last TXT-record key* rather than the service name. As a result:

- `remove_service` at line 127 compares `self.name_type == (name, type)`, where `name` is the actual service name. The comparison silently never matches, so `disconnect` is never sent on service teardown.

Rename the loop variables to `k, v` so the outer `name` is unambiguous.

## Red-green verification (in-process)

```
--- pre-fix: bug 1 (None value) ---
  signalk zeroconf exception 'NoneType' object has no attribute 'decode' b'' None   (log spam on every poll)
--- pre-fix: bug 2 (name_type shadowing) ---
  expected: ('instellen._http._tcp.local.', '_http._tcp.local.')
  actual  : (b'swname', '_http._tcp.local.')

--- post-fix ---
  bug 1: no exception printed, properties dict skips None entries silently.
  bug 2: self.name_type == ('instellen._http._tcp.local.', '_http._tcp.local.')
```

Diff is small (5 lines added, 3 changed) and confined to `add_service`. Ruff is clean on the changed lines.
