### PR TITLE
sensors: guard missing 'speed' in gps.update

### DIFF
--- a/pypilot/sensors.py
+++ b/pypilot/sensors.py
@@ -225,7 +225,8 @@ class gps(Sensor):
         if 'fix' in data: # flatten if needed
             data.update(data['fix'])
             del data['fix']
-        self.speed.set(data['speed'])
+        if 'speed' in data:
+            self.speed.set(data['speed'])
         if 'track' in data:
             self.track.set(data['track'])
         if 'declination' in data:


### PR DESCRIPTION
Fixes #253.

GPSD does not always emit a `speed` field in its TPV reports: low-fix modes (e.g. NO_FIX, 2D fix without ground-speed) and the older `fix` sub-object form can both arrive without it. The unconditional `self.speed.set(data['speed'])` on line 228 then raises `KeyError`, which escapes through `Sensor.write` → `Sensors.poll` → `autopilot.iteration` and takes the autopilot process down with the exact stack trace shown in the issue:

```
File "/usr/local/lib/python3.6/site-packages/pypilot/sensors.py", line 219, in update
    self.speed.set(data['speed'])
KeyError: 'speed'
```

Guard the assignment with `if 'speed' in data`, matching the existing pattern in `Water.update` at `sensors.py:300`. The other GPS fields (track, declination) already have the same guard, so this just fills the gap. Track and declination still update when only speed is missing, which is the desired behaviour for partial fixes.

Verified locally with a synthetic data dict:

```python
>>> data = {'track': 90.0, 'declination': 0.0}  # no 'speed'
>>> gps.update(data)
# before: KeyError: 'speed'
# after:  returns True, track/declination set, speed left as-is
```

Ruff is clean on the changed lines (pre-existing findings in `sensors.py` left for a separate cleanup PR).