### PR TITLE
nmea: send MWV wind direction in 0..359 range

### DIFF
--- a/pypilot/nmea.py
+++ b/pypilot/nmea.py
@@ -36,6 +36,7 @@ import serialprobe
 from bufferedsocket import LineBufferedNonBlockingSocket
 from client import pypilotClient
 from nonblockingpipe import NonBlockingPipe
+from resolv import resolv
 from sensors import source_priority
 from values import *
 
@@ -502,10 +503,12 @@ class Nmea:
                 if freq < rate:
                     if name == 'wind':
                         wind = self.sensors.wind
-                        self.send_nmea('APMWV,%.3f,R,%.3f,N,A' % (wind.direction.value, wind.speed.value))
+                        # NMEA MWV requires wind angle in 0..359, but
+                        # wind.direction is held in -180..180 by sensors.py.
+                        self.send_nmea('APMWV,%.3f,R,%.3f,N,A' % (resolv(wind.direction.value, 180), wind.speed.value))
                     elif name == 'truewind':
                         wind = self.sensors.truewind
-                        self.send_nmea('APMWV,%.3f,T,%.3f,N,A' % (wind.direction.value, wind.speed.value))
+                        self.send_nmea('APMWV,%.3f,T,%.3f,N,A' % (resolv(wind.direction.value, 180), wind.speed.value))
                     elif name == 'rudder':
                         self.send_nmea('APRSA,%.3f,A,,' % -self.sensors.rudder.angle.value)
                     period = 1/rate


### PR DESCRIPTION
Fixes #207.

The NMEA 0183 MWV (wind speed and angle) sentence specifies the wind-angle field in 0..359 degrees. The MWV sender in `Nmea.poll` uses `wind.direction.value` directly, which is normalised to -180..180 by `resolv()` in `sensors.py:104`, so negative angles travel out on the wire. The reporter observed OpenCPN's dashboard wind instrument pointing the wrong way as a result (linked screenshot in the issue).

Apply `resolv(value, 180)`, which the codebase already uses to fold an angle into the 0..360 half-open range. This matches the fix the reporter suggested and keeps the change localised to the sender. Receivers (`parse_nmea_wind`) are unaffected, since their downstream consumers re-resolve through `sensors.py` and accept either convention.

Spec reference: https://gpsd.gitlab.io/gpsd/NMEA.html#_mwv_wind_speed_and_angle

Verified locally:

```python
>>> from pypilot.resolv import resolv
>>> [resolv(v, 180) for v in (-180, -90, 0, 90, 179.9)]
[180, 270, 0, 90, 179.9]
```

Diff is +5/-2 (one import line, two formatter swaps, one explanatory comment). Ruff is clean on the changed lines.