### PR TITLE
nmea: return False on RSA parse failure instead of silent angle=0

### DIFF
--- a/pypilot/nmea.py
+++ b/pypilot/nmea.py
@@ -174,7 +174,7 @@ def parse_nmea_rudder(line):
     try:
         angle = float(data[1])
     except (ValueError, IndexError):
-        angle = False
+        return False  # require angle
 
     return 'rudder', {'angle': -angle}
 


### PR DESCRIPTION
`parse_nmea_rudder` catches a parse error from `float(data[1])` by setting `angle = False`, then proceeds to `return ('rudder', {'angle': -angle})`. Because `-False` evaluates to `0` in Python, a malformed RSA sentence silently reports a centred rudder. Downstream consumers (`Rudder.update`) have no way to distinguish "rudder is at 0" from "we could not parse the angle field at all".

```python
>>> parse_nmea_rudder('$IIRSA,,A,,*hh')
('rudder', {'angle': 0})   # bad RSA, but caller treats as "rudder centred"
```

Match the contract used by the sibling parsers in the same file: `parse_nmea_wind:153` and `parse_nmea_gps:125` both `return False` on parse failure, which the dispatch loop at `nmea.py:417` and `nmea.py:670` already handles via `if result:`. The fix swaps `angle = False` for `return False` and adds a `# require angle` comment matching the wind parser's `# require direction` note.

Verified locally:

```python
>>> parse_nmea_rudder('$IIRSA,,A,,*hh')
# before: ('rudder', {'angle': 0})
# after:  False  (caller skips the line, rudder state preserved)
```

No open issue references this one: noticed during a defensive-parsing audit alongside #207. Ruff is clean on the changed line.