### PR TITLE
sensors: raise NotImplementedError in abstract Sensor methods

### DIFF
--- a/pypilot/sensors.py
+++ b/pypilot/sensors.py
@@ -51,10 +51,10 @@ class Sensor:
         return True
 
     def reset(self):
-        raise 'reset should be overloaded'
+        raise NotImplementedError('reset should be overloaded')
 
     def update(self, data):
-        raise 'update should be overloaded'
+        raise NotImplementedError('update should be overloaded')
 
     def register(self, _type, name, *args, **kwargs):
         return self.client.register(_type(*([self.name + '.' + name] + list(args)), **kwargs))


### PR DESCRIPTION
`Sensor.reset` and `Sensor.update` are abstract placeholders that subclasses are required to override. Both use `raise 'should be overloaded'`, which worked in Python 2 (string exceptions) but raises `TypeError` in Python 3:

```python
>>> raise 'reset should be overloaded'
TypeError: exceptions must derive from BaseException
```

This `TypeError` path is dead code in normal operation because every concrete sensor (`BaseWind`, `APB`, `gps`, `Water`, `Rudder`) overrides both methods. If a future subclass is added without an override though, the original "subclass forgot to overload" intent is lost in a confusing `TypeError`. Switch to `NotImplementedError(message)`, which is the standard idiom and preserves the diagnostic text.

`ruff B016` ("Cannot raise a literal") flags both lines, which is what prompted finding this.

Tiny diff, no behaviour change in practice. Ruff is clean on the changed lines.