### PR TITLE
signalk: fix subprocess never executing the connect/send loop

### DIFF
--- a/pypilot/signalk.py
+++ b/pypilot/signalk.py
@@ -221,7 +221,6 @@ class signalk:
 
         self.sensors_pipe, self.sensors_pipe_out = NonBlockingPipe('signalk pipe', self.multiprocessing)
 
-        self.process = False
         if self.multiprocessing:
             self.zero_conf = ZeroConfProcess(self)
         else:
@@ -230,6 +229,10 @@ class signalk:
 
         if self.multiprocessing:
             import multiprocessing
+            # target=self.process resolves to the `def process` method below.
+            # Don't assign self.process before this line: an attribute with
+            # that name would shadow the method, leaving target=False and
+            # the subprocess a silent no-op.
             self.process = multiprocessing.Process(target=self.process, name='signalk', daemon=True)
             self.process.start()
         else:
@@ -430,6 +433,13 @@ class signalk:
         return delay
             
     def process(self):
+        # The subprocess inherits self.process pointing at the Process handle
+        # the parent created. poll() uses that attribute to decide whether to
+        # take the parent-side "drain pipe and return" branch or the worker
+        # branch (probe / connect_signalk / send). Clear it locally so this
+        # subprocess executes the worker branch; the parent's copy is
+        # unaffected by the fork.
+        self.process = False
         print('signalk process', os.getpid())
         time.sleep(6) # let other stuff load
         while True:


### PR DESCRIPTION
Two related defects cause every pypilot install to silently fail to publish anything to a SignalK server over the WebSocket. Both have to be fixed together; either alone leaves SignalK output broken.

## 1. The signalk subprocess never runs the target method (since `826aad8`)

```python
self.process = False
...
self.process = multiprocessing.Process(target=self.process,
                                       name='signalk', daemon=True)
self.process.start()
```

In Python the right-hand side of `target=self.process` is evaluated first. Because the attribute was set to `False` on the previous line, it shadows the `def process(self):` method defined later in the class, and `target` ends up as `False`. `multiprocessing.Process.run` is then a no-op:

```python
def run(self):
    if self._target:
        self._target(*self._args, **self._kwargs)
```

The subprocess starts, immediately exits with status 0, and shows up in the cleanup log as `Process name='signalk' ... stopped exitcode=0 daemon`. `ZeroConfProcess` is unaffected because it is a `Process` subclass and resolves `target=self.process` inside its own `__init__` before any attribute of that name exists.

**Fix:** drop the early `self.process = False` sentinel. Both branches below already assign `self.process` (a `Process` in the multiprocessing case, `False` otherwise), so the sentinel was redundant as well as harmful. A short comment is added to warn future editors.

## 2. Even after fix 1, the subprocess's `poll()` takes the parent branch (since `aad73ad`)

```python
def poll(self, timeout=0):
    if self.process:
        msg = self.sensors_pipe_out.recv()
        ...
        return
    ...                       # probe / connect / send work here
```

After fork, the child inherits `self.process` pointing at the parent's `Process` handle, so `if self.process:` is true in the child too. The child drains its own write-end of the pipe (which never fills) and returns forever, never reaching the probe/connect/send code.

**Fix:** in `def process(self):` (the subprocess entry point), set `self.process = False` immediately. This makes the subprocess's local view of the attribute falsy without affecting the parent's copy, so the child takes the worker branch and the parent keeps taking the pipe-drain branch.

## Verification

Verified end-to-end on a Raspberry Pi running pypilot 0.70. After both fixes:

- Subprocess survives past startup (no more `stopped exitcode=0` in the cleanup log).
- `signalk found ws://.../signalk/v1/stream` appears once `probe_signalk` succeeds.
- The stored token in `~/.pypilot/signalk-token` is replayed, `connect_signalk` opens the WebSocket, and IMU heading / GPS deltas appear on the SignalK side under the pypilot `$source`.

Diff is +11/-1, confined to `pypilot/signalk.py`. Ruff is clean on the changed lines (pre-existing findings in this file left for a separate cleanup PR).