### PR TITLE
signalk: default to port 3000 when signalk.host lacks one

### DIFF
--- a/pypilot/signalk.py
+++ b/pypilot/signalk.py
@@ -72,6 +72,9 @@ SIGNALK_HTTP_TIMEOUT = 5
 SIGNALK_BACKOFF_MIN = 5
 SIGNALK_BACKOFF_MAX = 60
 
+# Default SignalK HTTP/WS port. Used when signalk.host is a bare hostname.
+SIGNALK_DEFAULT_PORT = 3000
+
 # Subscription policy values permitted by the SignalK v1 spec.
 SIGNALK_POLICIES = ('instant', 'fixed', 'ideal')
 
@@ -465,6 +468,12 @@ class signalk:
             return
           
         manual_host = self.signalk_host.value.strip()
+        if manual_host and ':' not in manual_host:
+            # signalk_host_port is consumed as "host:port" throughout this
+            # module. A bare hostname from the user config defaults to the
+            # SignalK HTTP port so configs like "localhost" keep working
+            # without forcing the operator to remember the port.
+            manual_host = manual_host + ':' + str(SIGNALK_DEFAULT_PORT)
         if manual_host:
             if manual_host != self.signalk_host_port:
                 self.signalk_host_port = manual_host


### PR DESCRIPTION
The `signalk.host` property is a free-form string the user can set from the web UI or `pypilot.conf`. Internally pypilot keeps a single `signalk_host_port` string in `"host:port"` form which feeds the probe URL (`http://host:port/signalk`) and the WebSocket URL. The zeroconf path always builds the `host:port` string with both halves:

```python
host_port = socket.inet_ntoa(info.addresses[0]) + ':' + str(info.port)
```

The manual-host path does not. It assigns `signalk.host` directly to `signalk_host_port`. So a user-friendly value like `"localhost"` or `"openplotter.local"` turns into a probe URL of `http://localhost/signalk` and a WebSocket URL of `ws://localhost/signalk/v1/stream`, both of which talk to port 80 instead of the SignalK server on 3000. The probe times out, `signalk_host_port` is cleared, and pypilot loops forever between zeroconf discovery and manual-host failure without ever connecting.

This is a real upgrade hazard for anyone whose 0.6x config still carries `signalk.host` as a hostname plus `signalk.port` as a separate property (`signalk.port` has not been read since `826aad8`).

## Fix

When `signalk.host` has no colon, treat it as a bare hostname and append `:3000` (the standard SignalK HTTP/WS port). This matches the form the zeroconf path already produces. Users who set explicit `host:port` or `host:other-port` are unaffected. A new `SIGNALK_DEFAULT_PORT = 3000` module constant is added to match the existing `SIGNALK_HTTP_TIMEOUT` / `SIGNALK_BACKOFF_*` / `SIGNALK_POLICIES` convention.

## Verification

On a Raspberry Pi with `signalk.host="localhost"` (no port) and the signalk subprocess actually running (requires the companion fix that lets the subprocess execute the connect/send loop), pypilot now resolves the WebSocket URL to `ws://localhost:3000/signalk/v1/stream` and connects on the first probe rather than spinning. IMU heading / attitude deltas appear on the SignalK side under the pypilot `$source`.

Diff is +9/-0, confined to `pypilot/signalk.py`. Ruff is clean on the changed lines.