### PR TITLE
signalk: send wildcard unsubscribe sentinel, not per-path

### DIFF
--- a/pypilot/signalk.py
+++ b/pypilot/signalk.py
@@ -821,16 +821,13 @@ class signalk:
         self.subscribed[sensor] = subscribe
 
         if not subscribe:
-            # Unsubscribe the explicit paths belonging to this sensor rather
-            # than a wildcard. Some SignalK servers ignore wildcard
-            # unsubscribes which would leave stale subscriptions alive.
-            unsubscribe_paths = [
-                {'path': path} for path, _conv in signalk_table[sensor]
-            ]
-            subscription = {'context': 'vessels.self', 'unsubscribe': unsubscribe_paths}
-            debug('signalk unsubscribe', subscription)
+            # Node signalk-server only accepts the wildcard sentinel and
+            # throws on per-path unsubscribe. Clear everything here; the
+            # re-subscribe below restores the sensors we still want.
+            unsubscribe_all = {'context': '*', 'unsubscribe': [{'path': '*'}]}
+            debug('signalk unsubscribe', unsubscribe_all)
             try:
-                self.ws.send(pyjson.dumps(subscription)+'\n')
+                self.ws.send(pyjson.dumps(unsubscribe_all)+'\n')
             except Exception as e:
                 print('signalk failed to send', e)
                 self.disconnect_signalk()


### PR DESCRIPTION
The canonical Node implementation of signalk-server, which is what nearly every pypilot user runs (often via OpenPlotter or directly on a companion Pi), implements WebSocket unsubscribe in a single form. See `SubscriptionManager.unsubscribe` at `src/subscriptionmanager.ts:149-167` of https://github.com/SignalK/signalk-server: it accepts only the all-clear sentinel

```json
{"context": "*", "unsubscribe": [{"path": "*"}]}
```

and throws on anything else, including per-path entries that look otherwise spec-shaped. The throw propagates through the Primus data handler in `src/interfaces/ws.ts:311` and closes the session without recovery.

## What pypilot was sending

When a sensor source changes such that pypilot no longer wants that sensor from SignalK (for example, GPS just appeared on serial NMEA and now outranks the SignalK GPS), the current code sends a per-path unsubscribe listing only the paths belonging to that one sensor. Concretely, on a GPS source switch:

```json
{"context": "vessels.self", "unsubscribe": [
    {"path": "navigation.courseOverGroundTrue"},
    {"path": "navigation.speedOverGround"},
    {"path": "navigation.position"}
]}
```

Node signalk-server throws on receipt, drops the WebSocket, pypilot hits its exponential backoff, and the cycle repeats. The ws-server-side log shows an uncaught exception trace originating in `SubscriptionManager.unsubscribe` each time.

## Fix

Send the wildcard sentinel as the single unsubscribe form. The existing code path immediately below already rebuilds and re-sends the full subscribe list for whatever sensors still belong to SignalK (`signalk.py:867-871`), so the wildcard "clear everything" plus that re-subscribe leaves the desired subscriptions in place without ever issuing a form the server rejects.

A note on the old comment ("Some SignalK servers ignore wildcard unsubscribes which would leave stale subscriptions alive"): this is inverted relative to the reference server. Node signalk-server requires the wildcard form and throws on per-path. If there is an alternate implementation that genuinely silently ignores the wildcard, the cost of using it is at most a stale subscription on that server, which is strictly less harmful than crashing the session on every source change for everyone running the reference server.

## Verification

On a Raspberry Pi running pypilot 0.70 with a Node signalk-server 2.27.0:

- Before: signalk-server's journal logged the `Cannot set 8 bit(s)`-adjacent `Uncaught exception ... at SubscriptionManager.unsubscribe ... at Primus data handler` trace every time a pypilot source flipped to non-signalk, and pypilot's signalk subprocess would log `signalk server closed connection` and reconnect on backoff.
- After: signalk-server's journal is clean across a full pypilot startup that includes the GPS source switching from signalk to tcp (the unsubscribe-triggering case), and pypilot's WebSocket session stays up. IMU `attitude` deltas continue to land in the SignalK data tree under `$source: pypilot`.

Diff is +10/-9 in `pypilot/signalk.py`. No behavior change on the re-subscribe leg. Ruff is clean on the changed lines.