### PR TITLE
fix(web): correct malformed HTML and modernize web.py path/datetime

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -40,7 +40,7 @@
       <a class="tabItem" href="javascript:void(0)" onclick="openTab(event, 'Configuration');">
         <div class="w3-col tablink font-resizable">{{_('Configuration')}}</div>
       </a>
-      <a class="tabItem" href="javascript:void(0)" onclick="openTab(event, 'Statistics');" st>
+      <a class="tabItem" href="javascript:void(0)" onclick="openTab(event, 'Statistics');">
         <div class="w3-col tablink font-resizable">{{_('Statistics')}}</div>
       </a>
     </div>
@@ -52,27 +52,16 @@
         <div class="w3-col" style="font-size: 3em;width:30%;" id="heading">---</div>
 
         <div class="w3-col" style="font-size: 2em;width:20%;">{{_('Command')}}</div>
-        <div class="w3-col" style="font-size: 3em;width:30%;" id="heading_command">---</div
->
+        <div class="w3-col" style="font-size: 3em;width:30%;" id="heading_command">---</div>
       </div>
       <div id="steer_buttons_container" class="w3-row" >
-          <button id="port10" class="button font-resizable1 button-resizable" style="float:left">
-            <span id="port10">--</span>
-          </button>
-          <button id="port1" class="button font-resizable1 button-resizable" style="float:left"> <!-- force no space between buttons-->
-            <span id="port1">--</span>
-          </button>
+          <button id="port10" class="button font-resizable1 button-resizable" style="float:left">--</button>
+          <button id="port1" class="button font-resizable1 button-resizable" style="float:left">--</button> <!-- force no space between buttons-->
           <span id="center_span">
-          <button id="center_button" class="button font-resizable1 button-resizable">
-            <span id="center">|</span>
-          </button>
+          <button id="center_button" class="button font-resizable1 button-resizable">|</button>
           </span>
-          <button id="star10" class="button font-resizable1 button-resizable" style="float:right">
-            <span id="star10">--</span>
-          </button>
-          <button id="star1" class="button font-resizable1 button-resizable" style="float:right">
-            <span id="star1">--</span>
-          </button>
+          <button id="star10" class="button font-resizable1 button-resizable" style="float:right">--</button>
+          <button id="star1" class="button font-resizable1 button-resizable" style="float:right">--</button>
       </div>
       <br>
       <br>
@@ -118,9 +107,9 @@
       </div>
       -->
       {{_('Magnetic Heading Offset')}}
-      <input type="spin" id="imu_heading_offset" min=-180 max=180 value=0>Degrees</input>
-      <p><input type="checkbox" id="accel_calibration_locked">{{_('Lock Accelerometer Calibration')}}</input>
-      <p><input type="checkbox" id="compass_calibration_locked">{{_('Lock Compass Calibration')}}</input>
+      <input type="number" id="imu_heading_offset" min=-180 max=180 value=0>Degrees
+      <p><label><input type="checkbox" id="accel_calibration_locked">{{_('Lock Accelerometer Calibration')}}</label>
+      <p><label><input type="checkbox" id="compass_calibration_locked">{{_('Lock Compass Calibration')}}</label>
       </p>
       <br><a href="/calibrationplot">{{_('calibration plot')}}</a>
       <br>
@@ -133,7 +122,7 @@
       </p>
       <p>
         {{_('Rudder Range')}} 
-       <input type="number" id="rudder_range" min=10 max=100 value=30 style="text-align: right;"></input>&nbsp;{{_('Degrees')}}
+       <input type="number" id="rudder_range" min=10 max=100 value=30 style="text-align: right;">&nbsp;{{_('Degrees')}}
       </p>
     </div>
 
@@ -145,15 +134,15 @@
       </div>      
       <div id="configuration_container" ></div>
       <div id='language_selector'>
-          <span ="value_name">{{_('Language')}}:</span>
+          <span class="value_name">{{_('Language')}}:</span>
           <select id="language">'<option value="default">default</option></select>
       </div>
       <p>
       {{_('NMEA Client host:port (leave blank for none) eg: 192.168.0.1:10110')}}
-      <p><input type="text" id="nmea_client"></input>
+      <p><input type="text" id="nmea_client">
       <p>
       {{_('SignalK server host:port(leave blank for zeroconf) eg: 192.168.0.1:3000')}}
-      <p><input type="text" id="signalk_host"></input>
+      <p><input type="text" id="signalk_host">
     </div>
 
     <div id="Statistics" class="w3-container tab" style="font-size: 1em">
@@ -166,7 +155,6 @@
       <br>{{_('Runtime')}} <span id="runtime"></span>
       <br>{{_('Version')}} <span id="version"></span>
       <br>{{_('Servo')}}: <b><span id="servo_engaged"></span></b>
-      <br>{{_('Version')}}: <span id="version"></span>
       <br>
       <br><button id="logs" class="button font-resizable3 button-resizable2" onclick="window.location.href='logs';">{{_('Logs')}}</button>
     </div>

--- a/web/web.py
+++ b/web/web.py
@@ -8,6 +8,7 @@
 
 import os
 import sys
+from datetime import datetime, timezone
 
 from engineio.payload import Payload
 from flask import Flask, render_template, request
@@ -87,7 +88,7 @@ def log(name):
 
 @app.route('/wifi', methods=['GET', 'POST'])
 def wifi():
-    networking = '/home/tc/.pypilot/networking.txt'
+    networking = os.path.expanduser('~') + '/.pypilot/networking.txt'
     wifi = {'mode': 'Master', 'ssid': 'pypilot', 'key': '',
             'client_ssid': 'openplotter', 'client_key': '12345678', 'client_address': '10.10.10.60'}
     try:
@@ -130,10 +131,9 @@ def wifi():
                 if elements[3] == "*":
                     continue
 
-                from datetime import datetime
                 ts = int(elements[0])
                 if ts:
-                    ts = datetime.utcfromtimestamp(ts).strftime('%Y-%m-%d %H:%M:%S')
+                    ts = datetime.fromtimestamp(ts, timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
                 else:
                     ts = 'Never'
 


### PR DESCRIPTION
## Summary

Fixes a batch of HTML correctness defects in the web control UI plus two small `web.py` cleanups. No behavior changes intended: every fix either corrects invalid markup or aligns with conventions already used elsewhere in the repo.

### `web/templates/index.html`

- **Duplicate element IDs on the steer buttons.** Each `<button id="port10">` (and `port1`, `star10`, `star1`) wrapped a `<span>` carrying the *same* `id`. Duplicate IDs are invalid HTML, and the jQuery in `pypilot_control.js` only ever resolved the first match (the button), so the inner spans were dead weight. The button text is now set directly.
- **Duplicate `id="version"`.** The Statistics tab declared `id="version"` twice; removed the second one.
- **Invalid `<input>` markup.** `type="spin"` is not a real input type (now `type="number"`), and `<input>` is a void element so the `</input>` close tags on the heading-offset, calibration-lock, rudder-range, and NMEA/SignalK host fields were invalid. The two calibration-lock labels are now wrapped in `<label>` so the text toggles the checkbox.
- **Malformed attributes.** `<span ="value_name">` was missing `class`; a stray `st` token sat on the Statistics tab link.

### `web/web.py`

- `networking.txt` was resolved from a hardcoded `/home/tc/.pypilot/` path (a TinyCore-specific leftover), so the `/wifi` page silently no-ops on any other install. It now uses `os.path.expanduser('~')`, matching every other `.pypilot/` path in the repo, including `web.conf` in this same file.
- Replaced deprecated `datetime.utcfromtimestamp` (slated for removal in modern Python) with `datetime.fromtimestamp(ts, timezone.utc)`, and hoisted the import out of the lease-file loop.

## Test plan

- [x] `index.html` renders via Jinja with a representative context
- [x] No duplicate element IDs remain; no stray `</input>` or `type="spin"` in rendered output
- [x] `ruff check web/web.py` clean for the changed lines