### PR TITLE
fix(hat): resolve networking.txt path instead of hardcoding /home/tc

### DIFF
--- a/hat/menu.py
+++ b/hat/menu.py
@@ -443,7 +443,12 @@ class motor(menu):
                                      ValueEdit(_('period'), _('seconds'), 'servo.period'),
                                      ValueEdit(_('clutch pwm'), _('percent'), 'servo.clutch_pwm')])
 
-networking = '/home/tc/.pypilot/networking.txt'
+# os.path.expanduser is unavailable under micropython; the micropython
+# branch value is unused since the wifi page only runs on the Linux build
+if micropython:
+    networking = '/home/tc/.pypilot/networking.txt'
+else:
+    networking = os.path.expanduser('~') + '/.pypilot/networking.txt'
 default_network = {'mode': 'Master', 'ssid': 'pypilot', 'key':'', 'client_ssid': 'openplotter', 'client_key': '12345678'}
 
 class select_wifi(page):


### PR DESCRIPTION
## Summary

`hat/menu.py` hardcoded the wifi config file as `/home/tc/.pypilot/networking.txt`, a TinyCore (piCore) specific path. On any other Linux install the wifi menu silently fails to read or write that file. This resolves the path via `os.path.expanduser('~')`, matching the convention already used elsewhere in the `hat/` package (`hat.py:349`, `arduino.py:63`, `font.py:26`) and in `web/web.py`.

`menu.py` is also imported on the esp32/micropython target (`lcd_esp32` -> `lcd` -> `menu`), and `os.path.expanduser` does not exist in micropython's `os` module. Since this is a module-level assignment, an unguarded call would crash the import on esp32. The `expanduser` call is therefore guarded behind the `micropython` flag already defined at the top of the file. The micropython branch keeps the previous value: that path is non-functional on esp32 regardless, and every consumer (`setup_network`, `read_networking`) wraps file access in `try/except`.

## Test plan

- [x] `python3 -m py_compile hat/menu.py` passes
- [x] `ruff check hat/menu.py` clean for the changed lines
- [x] Confirmed `menu.py` reaches the esp32 build via the `lcd_esp32` import chain, so the micropython guard is required