### PR TITLE
signalk: add SSL support with a flag to accept self-signed certificates

### DIFF
--- a/pypilot/signalk.py
+++ b/pypilot/signalk.py
@@ -10,7 +10,9 @@
 import multiprocessing
 import os
 import socket
+import ssl
 import time
+from urllib.parse import urlparse
 
 import pyjson
 from client import pypilotClient
@@ -28,6 +30,18 @@ try:
     import requests
 except ImportError:
     requests = None
+else:
+    # urllib3 raises InsecureRequestWarning whenever a request runs with
+    # verify=False, which happens once signalk.tls.verify is disabled (to
+    # accept a self-signed cert) and would then flood the log. Silence just
+    # that warning at import: it never fires while verification is on, so
+    # disabling it unconditionally is harmless, and the security tradeoff
+    # stays visible through the signalk.tls.verify flag.
+    try:
+        from urllib3.exceptions import InsecureRequestWarning
+        requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+    except Exception:
+        pass
 
 try:
     from websocket import create_connection, WebSocketBadStatusException
@@ -289,10 +303,19 @@ class signalk:
         # has to opt in.
         self.put_enabled = self.client.register(
             BooleanProperty('signalk.put.enabled', False, persistent=True))
+        # When the SignalK server has SSL enabled it redirects http->https
+        # and advertises wss:// endpoints. Verify the server's certificate
+        # by default; disable to tolerate self-signed certificates, which
+        # is the common case for a SignalK server on the boat LAN. This
+        # relaxes verification for BOTH the HTTP probe/access requests and
+        # the websocket stream.
+        self.tls_verify = self.client.register(
+            BooleanProperty('signalk.tls.verify', True, persistent=True))
         self.signalk_host = self.client.register(Property('signalk.host', '', persistent=True))
 
         self.signalk_host_port = False
         self.signalk_ws_url = False
+        self.signalk_http_base = False
         self.ws = False
         self.last_manual_signalk_host = False
 
@@ -308,9 +331,21 @@ class signalk:
 
         try:
             r = requests.get('http://' + self.signalk_host_port + '/signalk',
-                             timeout=SIGNALK_HTTP_TIMEOUT)
+                             timeout=SIGNALK_HTTP_TIMEOUT,
+                             verify=self.tls_verify.value)
             contents = pyjson.loads(r.content)
-            self.signalk_ws_url = contents['endpoints']['v1']['signalk-ws'] + '?subscribe=none'
+            ws_url = contents['endpoints']['v1']['signalk-ws']
+            self.signalk_ws_url = ws_url + '?subscribe=none'
+            # Derive the HTTP(S) base for access requests from the
+            # advertised ws endpoint. An SSL server advertises
+            # wss://host:3443 (https on the same authority) and redirects
+            # the plain http://host:3000 we probed. Posting the access
+            # request to the http URL would hit that redirect, and requests
+            # downgrades a 302'd POST to a GET, silently breaking token
+            # enrollment. Use the advertised scheme and authority instead.
+            parsed = urlparse(ws_url)
+            scheme = 'https' if parsed.scheme == 'wss' else 'http'
+            self.signalk_http_base = scheme + '://' + parsed.netloc
         except Exception as e:
             print(_('failed to retrieve/parse data from'), self.signalk_host_port, e)
             time.sleep(5)
@@ -327,7 +362,9 @@ class signalk:
                 return
             self.last_access_request_time = time.monotonic()
             try:
-                r = requests.get(self.signalk_access_url, timeout=SIGNALK_HTTP_TIMEOUT)
+                r = requests.get(self.signalk_access_url,
+                                 timeout=SIGNALK_HTTP_TIMEOUT,
+                                 verify=self.tls_verify.value)
                 contents = pyjson.loads(r.content)
                 debug('signalk ' + _('see if token is ready'), self.signalk_access_url, contents)
                 if contents['state'] == 'COMPLETED':
@@ -370,14 +407,21 @@ class signalk:
 
             if self.uid.value == 'pypilot':
                 self.uid.set('pypilot-' + random_number_string(11))
-            r = requests.post('http://' + self.signalk_host_port + '/signalk/v1/access/requests',
+            # Use the scheme/authority discovered in probe_signalk so an
+            # SSL server's access request is posted to https directly
+            # rather than through the http->https redirect (which would
+            # downgrade the POST to a GET). Fall back to the probed host
+            # if probe has not run yet.
+            base = self.signalk_http_base or ('http://' + self.signalk_host_port)
+            r = requests.post(base + '/signalk/v1/access/requests',
                               data={"clientId": self.uid.value, "description": "pypilot"},
-                              timeout=SIGNALK_HTTP_TIMEOUT)
-            
+                              timeout=SIGNALK_HTTP_TIMEOUT,
+                              verify=self.tls_verify.value)
+
             contents = pyjson.loads(r.content)
             print('signalk post', contents)
             if contents['statusCode'] == 202 or contents['statusCode'] == 400:
-                self.signalk_access_url = 'http://' + self.signalk_host_port + contents['href']
+                self.signalk_access_url = base + contents['href']
                 print('signalk ' + _('request access url'), self.signalk_access_url)
         except Exception as e:
             print('signalk ' + _('error posting access'), e)
@@ -410,7 +454,14 @@ class signalk:
         self.signalk_values = {}
         self.keep_token = False
         try:
-            self.ws = create_connection(self.signalk_ws_url, header={'Authorization': 'JWT ' + self.token})
+            connect_kwargs = {'header': {'Authorization': 'JWT ' + self.token}}
+            # For a wss:// stream with verification disabled, tell
+            # websocket-client to skip certificate checks (self-signed
+            # certs). It also clears check_hostname when cert_reqs is
+            # CERT_NONE, so this is sufficient.
+            if self.signalk_ws_url.startswith('wss://') and not self.tls_verify.value:
+                connect_kwargs['sslopt'] = {'cert_reqs': ssl.CERT_NONE}
+            self.ws = create_connection(self.signalk_ws_url, **connect_kwargs)
             self.ws.settimeout(0) # nonblocking
             self.connect_attempts = 0
         except WebSocketBadStatusException as e:


### PR DESCRIPTION
A SignalK server with SSL enabled (`"ssl": true` in `settings.json`) redirects plain `http://host:3000` to `https://host:3443` and advertises `wss://` stream endpoints. By default that certificate is self-signed (the server generates one when SSL is enabled without a CA-signed cert), which is the common setup for a SignalK server on the boat LAN, often via OpenPlotter or a companion Pi.

pypilot's SignalK client only spoke plain `http`/`ws`. `probe_signalk` does `requests.get('http://' + host_port + '/signalk')`; `requests` follows the 302 to `https://host:3443`, then fails verification on the self-signed cert:

```
failed to retrieve/parse data from localhost:3000 HTTPSConnectionPool(host='localhost', port=3443):
  Max retries exceeded with url: /signalk
  (Caused by SSLError(SSLCertVerificationError(... self-signed certificate in certificate chain ...)))
```

The exception resets `signalk_host_port`, so the poll loop never advances past the probe to the token, the websocket, or subscriptions; it logs this every few seconds forever. Even past the probe, `connect_signalk` would hit the same wall: it connects to the advertised `wss://` URL, whose self-signed cert `websocket-client` also rejects by default.

## Fix

Add `signalk.tls.verify` (BooleanProperty, default `true`) and honor it across both handshakes:

- **HTTP probe and access requests:** pass `verify=signalk.tls.verify` to the three `requests` calls, so the redirect to the self-signed `https` endpoint is accepted when it is off.
- **WebSocket stream:** when the advertised URL is `wss://` and verification is off, pass `sslopt={'cert_reqs': ssl.CERT_NONE}` to `create_connection`. websocket-client clears `check_hostname` itself when `cert_reqs` is `CERT_NONE`, so that is sufficient.
- **Access-request POST:** derive the `https`/`wss` base from the server's advertised ws endpoint and POST straight to it. Posting to the probed `http` URL would hit the redirect, and `requests` downgrades a 302'd POST to a GET, silently breaking token enrollment.
- Silence urllib3's `InsecureRequestWarning` once at import so a verify-off server does not flood the log. It never fires while verification is on.

Verification stays on by default, so plain-`http` servers and CA-signed servers are unaffected. Disabling it is an explicit operator opt-in. Accepting a self-signed cert trades server authentication for an encrypted link; an operator who wants full verification can instead trust the server's CA and leave `signalk.tls.verify` on.

## Verification

On a Raspberry Pi running pypilot against Node `signalk-server` 2.28.0-beta.2 with `"ssl": true` (self-signed cert) and `signalk.host="localhost"`:

Before, the log repeated every ~6s with the `CERTIFICATE_VERIFY_FAILED` error above. After setting `signalk.tls.verify=false` and restarting:

```
signalk read token
signalk found wss://localhost:3443/signalk/v1/stream?subscribe=none
signalk connected to wss://localhost:3443/signalk/v1/stream?subscribe=none
sensor found gps signalk ...
```

The probe succeeds over the redirect, the existing token is accepted, the `wss://` stream connects with the self-signed cert, and GPS data flows from SignalK into pypilot. The connection stays up with no reconnect churn (socket to `:3443` stays `ESTAB`, no SSL errors after connect). Plain-`http`/`ws` and CA-signed servers are unaffected (default `signalk.tls.verify=true`, no `sslopt` for `ws://`).
